### PR TITLE
feat(idl-gen): Avoid using '<' and '>' in type names generated from generics

### DIFF
--- a/idlgen/src/lib.rs
+++ b/idlgen/src/lib.rs
@@ -295,11 +295,11 @@ mod tests {
   bool,
 };
 
-type SailsIdlgenTestsGenericStruct<u32> = struct {
+type SailsIdlgenTestsGenericStructForU32 = struct {
   p1: u32,
 };
 
-type SailsIdlgenTestsGenericStruct<str> = struct {
+type SailsIdlgenTestsGenericStructForStr = struct {
   p1: str,
 };
 
@@ -316,15 +316,15 @@ type SailsIdlgenTestsManyVariants = enum {
   Four: struct { a: u32, b: opt u16 },
   Five: struct { str, vec u8 },
   Six: struct { u32 },
-  Seven: SailsIdlgenTestsGenericEnum<u32, str>,
+  Seven: SailsIdlgenTestsGenericEnumForU32AndStr,
 };
 
-type SailsIdlgenTestsGenericEnum<u32, str> = enum {
+type SailsIdlgenTestsGenericEnumForU32AndStr = enum {
   Variant1: u32,
   Variant2: str,
 };
 
-type SailsIdlgenTestsGenericEnum<bool, u32> = enum {
+type SailsIdlgenTestsGenericEnumForBoolAndU32 = enum {
   Variant1: bool,
   Variant2: u32,
 };
@@ -334,9 +334,9 @@ type SailsIdlgenTestsThatParam = struct {
 };
 
 service {
-  DoThis : (p1: u32, p2: str, p3: struct { opt str, u8 }, p4: SailsIdlgenTestsTupleStruct, p5: SailsIdlgenTestsGenericStruct<u32>, p6: SailsIdlgenTestsGenericStruct<str>) -> str;
+  DoThis : (p1: u32, p2: str, p3: struct { opt str, u8 }, p4: SailsIdlgenTestsTupleStruct, p5: SailsIdlgenTestsGenericStructForU32, p6: SailsIdlgenTestsGenericStructForStr) -> str;
   DoThat : (par1: SailsIdlgenTestsDoThatParam) -> result (struct { str, u32 }, struct { str });
-  query This : (p1: u32, p2: str, p3: struct { opt str, u8 }, p4: SailsIdlgenTestsTupleStruct, p5: SailsIdlgenTestsGenericEnum<bool, u32>) -> result (struct { str, u32 }, str);
+  query This : (p1: u32, p2: str, p3: struct { opt str, u8 }, p4: SailsIdlgenTestsTupleStruct, p5: SailsIdlgenTestsGenericEnumForBoolAndU32) -> result (struct { str, u32 }, str);
   query That : (pr1: SailsIdlgenTestsThatParam) -> str;
 }
 ";

--- a/idlgen/src/type_names.rs
+++ b/idlgen/src/type_names.rs
@@ -142,13 +142,14 @@ fn type_name_by_path(
                 .ok_or_else(|| Error::UnsupprotedType(format!("{type_info:?}")))?
                 .id;
             resolve_type_name(type_registry, type_param_id, resolved_type_names)
+                .map(|type_name| type_name.to_case(Case::Pascal))
         })
         .collect::<Result<Vec<_>>>()?
-        .join(", ");
+        .join("And");
     let type_name = if type_param_names.is_empty() {
         type_name
     } else {
-        format!("{}<{}>", type_name, type_param_names)
+        format!("{}For{}", type_name, type_param_names)
     };
     if type_name.is_empty() {
         Err(Error::UnsupprotedType(format!("{type_info:?}")))
@@ -238,13 +239,13 @@ mod tests {
         let u32_struct_name = type_names.get(&u32_struct_id).unwrap();
         assert_eq!(
             u32_struct_name,
-            "SailsIdlgenTypeNamesTestsGenericStruct<u32>"
+            "SailsIdlgenTypeNamesTestsGenericStructForU32"
         );
 
         let string_struct_name = type_names.get(&string_struct_id).unwrap();
         assert_eq!(
             string_struct_name,
-            "SailsIdlgenTypeNamesTestsGenericStruct<str>"
+            "SailsIdlgenTypeNamesTestsGenericStructForStr"
         );
     }
 
@@ -264,13 +265,13 @@ mod tests {
         let u32_string_enum_name = type_names.get(&u32_string_enum_id).unwrap();
         assert_eq!(
             u32_string_enum_name,
-            "SailsIdlgenTypeNamesTestsGenericEnum<u32, str>"
+            "SailsIdlgenTypeNamesTestsGenericEnumForU32AndStr"
         );
 
         let bool_u32_enum_name = type_names.get(&bool_u32_enum_id).unwrap();
         assert_eq!(
             bool_u32_enum_name,
-            "SailsIdlgenTypeNamesTestsGenericEnum<bool, u32>"
+            "SailsIdlgenTypeNamesTestsGenericEnumForBoolAndU32"
         );
     }
 }


### PR DESCRIPTION
Avoid using the '<' and '>' symbols in type names generated from generics. Use `For' and 'And' instead.
GenericType<T1, u32> -> GenericTypeForT1AndU32