### PR TITLE
feat(idl-parser, idl-gen): Support fixed size arrays and maps in IDL

### DIFF
--- a/idlgen/src/lib.rs
+++ b/idlgen/src/lib.rs
@@ -93,6 +93,7 @@ handlebars_helper!(deref: |v: String| { v });
 mod tests {
     use super::*;
     use scale_info::TypeInfo;
+    use std::collections::BTreeMap;
     use std::result::Result as StdResult;
 
     #[allow(dead_code)]
@@ -136,6 +137,7 @@ mod tests {
         Five(String, Vec<u8>),
         Six((u32,)),
         Seven(GenericEnum<u32, String>),
+        Eight([BTreeMap<u32, String>; 10]),
     }
 
     #[allow(dead_code)]
@@ -225,6 +227,7 @@ type SailsIdlgenTestsManyVariants = enum {
   Five: struct { str, vec u8 },
   Six: struct { u32 },
   Seven: SailsIdlgenTestsGenericEnumForU32AndStr,
+  Eight: [map (u32, str), 10],
 };
 
 type SailsIdlgenTestsGenericEnumForU32AndStr = enum {

--- a/idlparser/src/ast/mod.rs
+++ b/idlparser/src/ast/mod.rs
@@ -126,8 +126,16 @@ impl Type {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum TypeDecl {
-    Optional(Box<TypeDecl>),
     Vector(Box<TypeDecl>),
+    Array {
+        item: Box<TypeDecl>,
+        len: u32,
+    },
+    Map {
+        key: Box<TypeDecl>,
+        value: Box<TypeDecl>,
+    },
+    Optional(Box<TypeDecl>),
     Result {
         ok: Box<TypeDecl>,
         err: Box<TypeDecl>,
@@ -282,6 +290,7 @@ mod tests {
             Four: struct { a: u32, b: opt u16 },
             Five: struct { str, u32 },
             Six: struct { u32 },
+            Seven: [map (u32, str), 10],
           };
 
           service {

--- a/idlparser/src/grammar.lalrpop
+++ b/idlparser/src/grammar.lalrpop
@@ -12,6 +12,8 @@ extern {
         ")" => Token::RParen,
         "{" => Token::LBrace,
         "}" => Token::RBrace,
+        "[" => Token::LBracket,
+        "]" => Token::RBracket,
         ";" => Token::Semicolon,
         ":" => Token::Colon,
         "," => Token::Comma,
@@ -21,11 +23,13 @@ extern {
         "type" => Token::Type,
         "struct" => Token::Struct,
         "enum" => Token::Enum,
-        "id" => Token::Id(<String>),
         "opt" => Token::Opt,
         "result" => Token::Result,
         "vec" => Token::Vec,
+        "map" => Token::Map,
         "null" => Token::Null,
+        "id" => Token::Id(<String>),
+        "num" => Token::Num(<u32>),
     }
 }
 
@@ -57,8 +61,10 @@ Type: Type = {
 }
 
 TypeDecl: TypeDecl = {
-    "opt" <TypeDecl> => TypeDecl::Optional(Box::new(<>)),
     "vec" <TypeDecl> => TypeDecl::Vector(Box::new(<>)),
+    "[" <item: TypeDecl> "," <len: "num"> "]" => TypeDecl::Array { item: Box::new(item), len },
+    "map" "(" <key: TypeDecl> "," <value: TypeDecl> ")" => TypeDecl::Map { key: Box::new(key), value: Box::new(value) },
+    "opt" <TypeDecl> => TypeDecl::Optional(Box::new(<>)),
     "result" "(" <ok: TypeDecl> "," <err: TypeDecl> ")" => TypeDecl::Result { ok: Box::new(ok), err: Box::new(err) },
     "null" => TypeDecl::Id(TypeId::Primitive(PrimitiveType::Null)),
     <"id"> => match PrimitiveType::str_to_enum(&<>) {

--- a/idlparser/src/lexer.rs
+++ b/idlparser/src/lexer.rs
@@ -46,6 +46,10 @@ pub(crate) enum Token {
     LBrace,
     #[token("}")]
     RBrace,
+    #[token("[")]
+    LBracket,
+    #[token("]")]
+    RBracket,
     #[token(";")]
     Semicolon,
     #[token(":")]
@@ -72,8 +76,12 @@ pub(crate) enum Token {
     Result,
     #[token("vec")]
     Vec,
+    #[token("map")]
+    Map,
     #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*", |lex| lex.slice().to_string())]
     Id(String),
+    #[regex(r"[0-9]+", |lex| lex.slice().parse().ok())]
+    Num(u32),
 }
 
 impl Display for Token {
@@ -93,13 +101,13 @@ mod tests {
           type ThisThatSvcAppTupleStruct = struct {
             bool,
           };
-          
+
           type ThisThatSvcAppDoThatParam = struct {
             p1: u32,
             p2: str,
             p3: ThisThatSvcAppManyVariants,
           };
-          
+
           type ThisThatSvcAppManyVariants = enum {
             One,
             Two: u32,
@@ -107,8 +115,9 @@ mod tests {
             Four: struct { a: u32, b: opt u16 },
             Five: struct { str, u32 },
             Six: struct { u32 },
+            Seven: [map (u32, str), 10],
           };
-          
+
           service {
             DoThis : (p1: u32, p2: str, p3: struct { opt str, u8 }, p4: ThisThatSvcAppTupleStruct) -> struct { str, u32 };
             DoThat : (param: ThisThatSvcAppDoThatParam) -> result (struct { str, u32 }, struct { str });


### PR DESCRIPTION
Arrays are supported in form of
`[<item_type>, <len>]`, e.g. `[u8, 10]`
Maps are supported in form of
`map (<key_type>, <value_type>)`, e.g. `map (u32, vec u8)`

Visitor is extended with new methods
`visit_array_type_decl(item_type_decl: &TypeDecl, len: u32)`
`visit_map_type_decl(key_type_decl: &TypeDecl, value_type_decl: &TypeDecl)`