### PR TITLE
feat(runtime): Introduce runtime libraries and some primitive types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3638,20 +3638,18 @@ name = "rmrk-catalog"
 version = "0.1.0"
 dependencies = [
  "gear-wasm-builder",
- "gstd",
  "rmrk-catalog-app",
- "sails-exec-context-gstd",
  "sails-idlgen",
+ "sails-rtl-gstd",
 ]
 
 [[package]]
 name = "rmrk-catalog-app"
 version = "0.1.0"
 dependencies = [
- "gstd",
  "parity-scale-codec",
- "sails-exec-context-abstractions",
  "sails-macros",
+ "sails-rtl",
  "sails-service-meta",
  "scale-info",
 ]
@@ -3661,13 +3659,12 @@ name = "rmrk-resource"
 version = "0.1.0"
 dependencies = [
  "gear-wasm-builder",
- "gstd",
  "gtest",
  "rmrk-catalog",
  "rmrk-catalog-app",
  "rmrk-resource-app",
- "sails-exec-context-gstd",
  "sails-idlgen",
+ "sails-rtl-gstd",
  "sails-sender",
 ]
 
@@ -3679,8 +3676,8 @@ dependencies = [
  "gstd",
  "parity-scale-codec",
  "sails-clientgen",
- "sails-exec-context-abstractions",
  "sails-macros",
+ "sails-rtl",
  "sails-sender",
  "sails-service-meta",
  "scale-info",
@@ -3763,18 +3760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sails-exec-context-abstractions"
-version = "0.0.1"
-
-[[package]]
-name = "sails-exec-context-gstd"
-version = "0.0.1"
-dependencies = [
- "gstd",
- "sails-exec-context-abstractions",
-]
-
-[[package]]
 name = "sails-idlgen"
 version = "0.0.1"
 dependencies = [
@@ -3821,6 +3806,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "sails-rtl"
+version = "0.0.1"
+dependencies = [
+ "hashbrown 0.14.3",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "sails-rtl-gstd"
+version = "0.0.1"
+dependencies = [
+ "gstd",
+ "sails-rtl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ members = [
     "examples/rmrk/resource/wasm",
     "examples/this-that-svc/app",
     "examples/this-that-svc/wasm",
-    "exec-context/abstractions",
-    "exec-context/gstd",
     "idlgen",
     "idlparser",
     "macros",
     "macros/core",
+    "runtimes/gstd",
+    "runtimes/rtl",
     "sender",
     "service-meta",
 ]
@@ -34,6 +34,7 @@ gstd = "1.1.1"
 gtest = "1.1.1"
 gwasm-builder = { package = "gear-wasm-builder", version = "1.1.1" }
 handlebars = "4.4"
+hashbrown = "0.14"
 insta = "1.34"
 itertools = "0.12"
 lalrpop = { version = "0.20", default-features = false }
@@ -45,11 +46,12 @@ proc-macro-error = "1.0"
 proc-macro2 = { version = "1", default-features = false }
 quote = "1.0"
 sails-clientgen = { path = "client-gen" }
-sails-exec-context-abstractions = { path = "exec-context/abstractions" }
 sails-exec-context-gstd = { path = "exec-context/gstd" }
 sails-idlgen = { path = "idlgen" }
 sails-idlparser = { path = "idlparser" }
 sails-macros = { path = "macros" }
+sails-rtl = { path = "runtimes/rtl" }
+sails-rtl-gstd = { path = "runtimes/gstd" }
 sails-sender = { path = "sender" }
 sails-service-meta = { path = "service-meta" }
 scale-info = { version = "2.10", default-features = false }

--- a/client-gen/src/snapshots/sails_clientgen__generator__tests__rmrk_works.snap
+++ b/client-gen/src/snapshots/sails_clientgen__generator__tests__rmrk_works.snap
@@ -20,13 +20,13 @@ pub trait Service {
     fn add_equippables(
         &mut self,
         part_id: u32,
-        collection_ids: Vec<GstdCommonPrimitivesActorId>,
-    ) -> Call<Result<(u32, Vec<GstdCommonPrimitivesActorId>), RmrkCatalogAppErrorsError>>;
+        collection_ids: Vec<SailsRtlTypesActorId>,
+    ) -> Call<Result<(u32, Vec<SailsRtlTypesActorId>), RmrkCatalogAppErrorsError>>;
     fn remove_equippable(
         &mut self,
         part_id: u32,
-        collection_id: GstdCommonPrimitivesActorId,
-    ) -> Call<Result<(u32, GstdCommonPrimitivesActorId), RmrkCatalogAppErrorsError>>;
+        collection_id: SailsRtlTypesActorId,
+    ) -> Call<Result<(u32, SailsRtlTypesActorId), RmrkCatalogAppErrorsError>>;
     fn reset_equippables(&mut self, part_id: u32) -> Call<Result<(), RmrkCatalogAppErrorsError>>;
     fn set_equippables_to_all(
         &mut self,
@@ -36,7 +36,7 @@ pub trait Service {
     fn equippable(
         &self,
         part_id: u32,
-        collection_id: GstdCommonPrimitivesActorId,
+        collection_id: SailsRtlTypesActorId,
     ) -> Call<Result<bool, RmrkCatalogAppErrorsError>>;
 }
 
@@ -67,15 +67,15 @@ impl<'a> Service for Client<'a> {
     fn add_equippables(
         &mut self,
         part_id: u32,
-        collection_ids: Vec<GstdCommonPrimitivesActorId>,
-    ) -> Call<Result<(u32, Vec<GstdCommonPrimitivesActorId>), RmrkCatalogAppErrorsError>> {
+        collection_ids: Vec<SailsRtlTypesActorId>,
+    ) -> Call<Result<(u32, Vec<SailsRtlTypesActorId>), RmrkCatalogAppErrorsError>> {
         Call::new(self.sender, "AddEquippables", (part_id, collection_ids))
     }
     fn remove_equippable(
         &mut self,
         part_id: u32,
-        collection_id: GstdCommonPrimitivesActorId,
-    ) -> Call<Result<(u32, GstdCommonPrimitivesActorId), RmrkCatalogAppErrorsError>> {
+        collection_id: SailsRtlTypesActorId,
+    ) -> Call<Result<(u32, SailsRtlTypesActorId), RmrkCatalogAppErrorsError>> {
         Call::new(self.sender, "RemoveEquippable", (part_id, collection_id))
     }
     fn reset_equippables(&mut self, part_id: u32) -> Call<Result<(), RmrkCatalogAppErrorsError>> {
@@ -93,7 +93,7 @@ impl<'a> Service for Client<'a> {
     fn equippable(
         &self,
         part_id: u32,
-        collection_id: GstdCommonPrimitivesActorId,
+        collection_id: SailsRtlTypesActorId,
     ) -> Call<Result<bool, RmrkCatalogAppErrorsError>> {
         Call::new(self.sender, "Equippable", (part_id, collection_id))
     }
@@ -110,12 +110,12 @@ pub struct RmrkCatalogAppPartsFixedPart {
 }
 #[derive(PartialEq, Debug, Encode, Decode)]
 pub struct RmrkCatalogAppPartsSlotPart {
-    equippable: Vec<GstdCommonPrimitivesActorId>,
+    equippable: Vec<SailsRtlTypesActorId>,
     z: Option<u32>,
     metadata_uri: String,
 }
 #[derive(PartialEq, Debug, Encode, Decode)]
-pub struct GstdCommonPrimitivesActorId([u8; 32]);
+pub struct SailsRtlTypesActorId([u8; 32]);
 #[derive(PartialEq, Debug, Encode, Decode)]
 pub enum RmrkCatalogAppErrorsError {
     PartIdCantBeZero,

--- a/examples/rmrk/catalog/app/Cargo.toml
+++ b/examples/rmrk/catalog/app/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gstd.workspace = true
 parity-scale-codec = { workspace = true, features = ["derive"] }
-sails-exec-context-abstractions.workspace = true
 sails-macros.workspace = true
+sails-rtl.workspace = true
 sails-service-meta.workspace = true
 scale-info = { workspace = true, features = ["derive"] }

--- a/examples/rmrk/catalog/app/src/errors.rs
+++ b/examples/rmrk/catalog/app/src/errors.rs
@@ -1,4 +1,4 @@
-use gstd::prelude::*;
+use sails_rtl::{Encode, TypeInfo};
 
 #[derive(Encode, TypeInfo)]
 pub enum Error {

--- a/examples/rmrk/catalog/app/src/lib.rs
+++ b/examples/rmrk/catalog/app/src/lib.rs
@@ -1,21 +1,19 @@
 #![no_std]
 
 use errors::Error;
-use gstd::{
-    collections::{BTreeMap, BTreeSet},
-    prelude::*,
-    ActorId,
-};
 use parts::{CollectionId, Part, PartId, SlotPart};
-use sails_exec_context_abstractions::ExecContext;
 use sails_macros::gservice;
+use sails_rtl::{
+    collections::{BTreeMap, BTreeSet},
+    Result as RtlResult, *,
+};
 
 pub mod errors;
 pub mod parts;
 
 static mut CATALOG_ADMIN: Option<ActorId> = None;
 
-type Result<T> = gstd::Result<T, Error>;
+type Result<T> = RtlResult<T, Error>;
 
 type PartMap<K, V> = BTreeMap<K, V>;
 
@@ -32,7 +30,7 @@ pub struct Catalog<'a, TExecContext: ExecContext> {
 
 impl<'a, TExecContext: ExecContext> Catalog<'a, TExecContext>
 where
-    TExecContext: ExecContext<ActorId = ActorId>,
+    TExecContext: ExecContext,
 {
     pub fn new(data: &'a mut CatalogData, exec_context: TExecContext) -> Self {
         unsafe {
@@ -45,7 +43,7 @@ where
 #[gservice]
 impl<'a, TExecContext> Catalog<'a, TExecContext>
 where
-    TExecContext: ExecContext<ActorId = ActorId>,
+    TExecContext: ExecContext,
 {
     pub fn add_parts(&mut self, parts: PartMap<PartId, Part>) -> Result<PartMap<PartId, Part>> {
         self.require_admin()?;

--- a/examples/rmrk/catalog/app/src/parts.rs
+++ b/examples/rmrk/catalog/app/src/parts.rs
@@ -1,4 +1,4 @@
-use gstd::{prelude::*, ActorId};
+use sails_rtl::*;
 
 pub type CollectionId = ActorId;
 pub type ZIndex = u32;

--- a/examples/rmrk/catalog/wasm/Cargo.toml
+++ b/examples/rmrk/catalog/wasm/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gstd.workspace = true
-sails-exec-context-gstd.workspace = true
 rmrk-catalog-app = { path = "../app" }
+sails-rtl-gstd.workspace = true
 
 [build-dependencies]
 gwasm-builder.workspace = true

--- a/examples/rmrk/catalog/wasm/rmrk-catalog.idl
+++ b/examples/rmrk/catalog/wasm/rmrk-catalog.idl
@@ -9,12 +9,12 @@ type RmrkCatalogAppPartsFixedPart = struct {
 };
 
 type RmrkCatalogAppPartsSlotPart = struct {
-  equippable: vec GstdCommonPrimitivesActorId,
+  equippable: vec SailsRtlTypesActorId,
   z: opt u32,
   metadata_uri: str,
 };
 
-type GstdCommonPrimitivesActorId = struct {
+type SailsRtlTypesActorId = struct {
   [u8, 32],
 };
 
@@ -31,10 +31,10 @@ type RmrkCatalogAppErrorsError = enum {
 service {
   AddParts : (parts: map (u32, RmrkCatalogAppPartsPart)) -> result (map (u32, RmrkCatalogAppPartsPart), RmrkCatalogAppErrorsError);
   RemoveParts : (part_ids: vec u32) -> result (vec u32, RmrkCatalogAppErrorsError);
-  AddEquippables : (part_id: u32, collection_ids: vec GstdCommonPrimitivesActorId) -> result (struct { u32, vec GstdCommonPrimitivesActorId }, RmrkCatalogAppErrorsError);
-  RemoveEquippable : (part_id: u32, collection_id: GstdCommonPrimitivesActorId) -> result (struct { u32, GstdCommonPrimitivesActorId }, RmrkCatalogAppErrorsError);
+  AddEquippables : (part_id: u32, collection_ids: vec SailsRtlTypesActorId) -> result (struct { u32, vec SailsRtlTypesActorId }, RmrkCatalogAppErrorsError);
+  RemoveEquippable : (part_id: u32, collection_id: SailsRtlTypesActorId) -> result (struct { u32, SailsRtlTypesActorId }, RmrkCatalogAppErrorsError);
   ResetEquippables : (part_id: u32) -> result (null, RmrkCatalogAppErrorsError);
   SetEquippablesToAll : (part_id: u32) -> result (null, RmrkCatalogAppErrorsError);
   query Part : (part_id: u32) -> opt RmrkCatalogAppPartsPart;
-  query Equippable : (part_id: u32, collection_id: GstdCommonPrimitivesActorId) -> result (bool, RmrkCatalogAppErrorsError);
+  query Equippable : (part_id: u32, collection_id: SailsRtlTypesActorId) -> result (bool, RmrkCatalogAppErrorsError);
 }

--- a/examples/rmrk/catalog/wasm/src/lib.rs
+++ b/examples/rmrk/catalog/wasm/src/lib.rs
@@ -1,8 +1,7 @@
 #![no_std]
 
-use gstd::msg;
 use rmrk_catalog_app::{requests, Catalog, CatalogData};
-use sails_exec_context_gstd::GStdExecContext;
+use sails_rtl_gstd::{gstd, gstd::msg, GStdExecContext};
 
 static mut CATALOG_DATA: Option<CatalogData> = None;
 

--- a/examples/rmrk/resource/app/Cargo.toml
+++ b/examples/rmrk/resource/app/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 gstd.workspace = true
 parity-scale-codec = { workspace = true, features = ["derive"] }
-sails-exec-context-abstractions.workspace = true
 sails-macros.workspace = true
+sails-rtl.workspace = true
 sails-sender.workspace = true
 sails-service-meta.workspace = true
 scale-info = { workspace = true, features = ["derive"] }

--- a/examples/rmrk/resource/app/src/errors.rs
+++ b/examples/rmrk/resource/app/src/errors.rs
@@ -1,6 +1,6 @@
-use gstd::prelude::*;
+use sails_rtl::{Decode, Encode, Result as RtlResult, TypeInfo};
 
-pub type Result<T> = gstd::Result<T, Error>;
+pub type Result<T> = RtlResult<T, Error>;
 
 #[derive(Encode, Decode, TypeInfo, Debug)]
 pub enum Error {

--- a/examples/rmrk/resource/app/src/lib.rs
+++ b/examples/rmrk/resource/app/src/lib.rs
@@ -114,3 +114,105 @@ fn resource_storage_data_mut() -> &'static mut ResourceStorageData {
 fn resource_storage_admin() -> &'static ActorId {
     unsafe { RESOURCE_STORAGE_ADMIN.as_ref().unwrap() }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use catalogs::{
+        GstdCommonPrimitivesActorId, RmrkCatalogAppErrorsError, RmrkCatalogAppPartsPart,
+    };
+    use gstd::{collections::BTreeMap, result::Result as StdResult};
+    use resources::BasicResource;
+    use sails_sender::Call;
+
+    #[test]
+    fn test_add_resource_entry() {
+        let mut resource_storage =
+            ResourceStorage::new(ExecContextMock { actor_id: 1.into() }, CatalogClientMock);
+        let resource = Resource::Basic(BasicResource {
+            src: "src".to_string(),
+            thumb: None,
+            metadata_uri: "metadata_uri".to_string(),
+        });
+        let (actual_resource_id, actual_resource) = resource_storage
+            .add_resource_entry(1, resource.clone())
+            .unwrap();
+        assert_eq!(actual_resource_id, 1);
+        assert_eq!(actual_resource, resource);
+    }
+
+    struct ExecContextMock {
+        actor_id: ActorId,
+    }
+
+    impl ExecContext for ExecContextMock {
+        type ActorId = ActorId;
+
+        fn actor_id(&self) -> &ActorId {
+            &self.actor_id
+        }
+    }
+
+    struct CatalogClientMock;
+
+    impl CatalogClient for CatalogClientMock {
+        fn add_parts(
+            &mut self,
+            _parts: BTreeMap<u32, RmrkCatalogAppPartsPart>,
+        ) -> Call<StdResult<BTreeMap<u32, RmrkCatalogAppPartsPart>, RmrkCatalogAppErrorsError>>
+        {
+            unimplemented!()
+        }
+
+        fn remove_parts(
+            &mut self,
+            _part_ids: Vec<u32>,
+        ) -> Call<StdResult<Vec<u32>, RmrkCatalogAppErrorsError>> {
+            unimplemented!()
+        }
+
+        fn add_equippables(
+            &mut self,
+            _part_id: u32,
+            _collection_ids: Vec<GstdCommonPrimitivesActorId>,
+        ) -> Call<StdResult<(u32, Vec<GstdCommonPrimitivesActorId>), RmrkCatalogAppErrorsError>>
+        {
+            unimplemented!()
+        }
+
+        fn remove_equippable(
+            &mut self,
+            _part_id: u32,
+            _collection_id: GstdCommonPrimitivesActorId,
+        ) -> Call<StdResult<(u32, GstdCommonPrimitivesActorId), RmrkCatalogAppErrorsError>>
+        {
+            unimplemented!()
+        }
+
+        fn reset_equippables(
+            &mut self,
+            _part_id: u32,
+        ) -> Call<StdResult<(), RmrkCatalogAppErrorsError>> {
+            unimplemented!()
+        }
+
+        fn set_equippables_to_all(
+            &mut self,
+            _part_id: u32,
+        ) -> Call<StdResult<(), RmrkCatalogAppErrorsError>> {
+            unimplemented!()
+        }
+
+        fn part(&self, _part_id: u32) -> Call<Option<RmrkCatalogAppPartsPart>> {
+            unimplemented!()
+        }
+
+        fn equippable(
+            &self,
+            _part_id: u32,
+            _collection_id: GstdCommonPrimitivesActorId,
+        ) -> Call<StdResult<bool, RmrkCatalogAppErrorsError>> {
+            unimplemented!()
+        }
+    }
+}

--- a/examples/rmrk/resource/app/src/resources.rs
+++ b/examples/rmrk/resource/app/src/resources.rs
@@ -1,4 +1,4 @@
-use gstd::{prelude::*, ActorId};
+use sails_rtl::*;
 
 pub type PartId = u32;
 

--- a/examples/rmrk/resource/app/src/resources.rs
+++ b/examples/rmrk/resource/app/src/resources.rs
@@ -4,14 +4,14 @@ pub type PartId = u32;
 
 pub type ResourceId = u8;
 
-#[derive(Decode, Encode, TypeInfo, Clone, Debug)]
+#[derive(Decode, Encode, TypeInfo, Clone, Debug, PartialEq, Eq)]
 pub enum Resource {
     Basic(BasicResource),
     Slot(SlotResource),
     Composed(ComposedResource),
 }
 
-#[derive(Decode, Encode, TypeInfo, Clone, Debug)]
+#[derive(Decode, Encode, TypeInfo, Clone, Debug, PartialEq, Eq)]
 pub struct BasicResource {
     /// URI like IPFS hash
     pub src: String,
@@ -24,7 +24,7 @@ pub struct BasicResource {
     pub metadata_uri: String,
 }
 
-#[derive(Decode, Encode, TypeInfo, Clone, Debug)]
+#[derive(Decode, Encode, TypeInfo, Clone, Debug, PartialEq, Eq)]
 pub struct ComposedResource {
     /// URI like ipfs hash
     pub src: String,
@@ -43,7 +43,7 @@ pub struct ComposedResource {
     pub parts: Vec<PartId>,
 }
 
-#[derive(Decode, Encode, TypeInfo, Clone, Debug)]
+#[derive(Decode, Encode, TypeInfo, Clone, Debug, PartialEq, Eq)]
 pub struct SlotResource {
     /// URI like ipfs hash
     pub src: String,

--- a/examples/rmrk/resource/wasm/Cargo.toml
+++ b/examples/rmrk/resource/wasm/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gstd.workspace = true
-sails-exec-context-gstd.workspace = true
-sails-sender.workspace = true
 rmrk-resource-app = { path = "../app" }
+sails-rtl-gstd.workspace = true
+sails-sender.workspace = true
 
 [build-dependencies]
 gwasm-builder.workspace = true

--- a/examples/rmrk/resource/wasm/rmrk-resource.idl
+++ b/examples/rmrk/resource/wasm/rmrk-resource.idl
@@ -14,11 +14,11 @@ type RmrkResourceAppResourcesSlotResource = struct {
   src: str,
   thumb: str,
   metadata_uri: str,
-  base: GstdCommonPrimitivesActorId,
+  base: SailsRtlTypesActorId,
   slot: u32,
 };
 
-type GstdCommonPrimitivesActorId = struct {
+type SailsRtlTypesActorId = struct {
   [u8, 32],
 };
 
@@ -26,7 +26,7 @@ type RmrkResourceAppResourcesComposedResource = struct {
   src: str,
   thumb: str,
   metadata_uri: str,
-  base: GstdCommonPrimitivesActorId,
+  base: SailsRtlTypesActorId,
   parts: vec u32,
 };
 

--- a/examples/rmrk/resource/wasm/src/lib.rs
+++ b/examples/rmrk/resource/wasm/src/lib.rs
@@ -1,8 +1,7 @@
 #![no_std]
 
-use gstd::msg;
 use rmrk_resource_app::{requests, CatalogClientImpl, ResourceStorage};
-use sails_exec_context_gstd::GStdExecContext;
+use sails_rtl_gstd::{gstd, gstd::msg, GStdExecContext};
 use sails_sender::GStdSender;
 
 #[no_mangle]

--- a/examples/rmrk/resource/wasm/tests/resources.rs
+++ b/examples/rmrk/resource/wasm/tests/resources.rs
@@ -1,12 +1,11 @@
 use core::cell::OnceCell;
-use gstd::{ActorId, Decode, Encode};
 use gtest::{Program, RunResult, System};
 use rmrk_catalog_app::parts::{FixedPart, Part};
 use rmrk_resource_app::{
     errors::{Error as ResourceStorageError, Result as ResourceStorageResult},
     resources::{ComposedResource, PartId, Resource, ResourceId},
 };
-use std::collections::BTreeMap;
+use sails_rtl_gstd::{collections::BTreeMap, ActorId, Decode, Encode};
 
 const CATALOG_PROGRAM_WASM_PATH: &str =
     "../../../../target/wasm32-unknown-unknown/debug/rmrk_catalog.wasm";

--- a/exec-context/abstractions/Cargo.toml
+++ b/exec-context/abstractions/Cargo.toml
@@ -1,6 +1,0 @@
-[package]
-name = "sails-exec-context-abstractions"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
-license.workspace = true

--- a/exec-context/abstractions/src/lib.rs
+++ b/exec-context/abstractions/src/lib.rs
@@ -1,7 +1,0 @@
-#![no_std]
-
-pub trait ExecContext {
-    type ActorId;
-
-    fn actor_id(&self) -> &Self::ActorId;
-}

--- a/js/src/generate/types-gen.ts
+++ b/js/src/generate/types-gen.ts
@@ -21,7 +21,7 @@ export class TypesGenerator {
 
   private generateStruct(name: string, def: TypeDef) {
     if (def.asStruct.isTuple) {
-      if (name === 'GstdCommonPrimitivesActorId') {
+      if (name === 'SailsRtlTypesActorId') {
         return this._out.line(`export type ${name} = ${'`0x${string}`'}`).line();
       }
       return this._out.line(`export type ${name} = ${getJsTypeDef(def)}`).line();

--- a/runtimes/gstd/Cargo.toml
+++ b/runtimes/gstd/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sails-exec-context-gstd"
+name = "sails-rtl-gstd"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -7,4 +7,4 @@ license.workspace = true
 
 [dependencies]
 gstd.workspace = true
-sails-exec-context-abstractions.workspace = true
+sails-rtl.workspace = true

--- a/runtimes/gstd/src/lib.rs
+++ b/runtimes/gstd/src/lib.rs
@@ -1,7 +1,11 @@
 #![no_std]
 
-use gstd::{cell::OnceCell, msg, ActorId};
-use sails_exec_context_abstractions::ExecContext;
+use crate::{cell::OnceCell, gstd::msg};
+pub use sails_rtl::*;
+
+pub mod gstd {
+    pub use ::gstd::*;
+}
 
 #[derive(Default)]
 pub struct GStdExecContext {
@@ -17,9 +21,8 @@ impl GStdExecContext {
 }
 
 impl ExecContext for GStdExecContext {
-    type ActorId = ActorId;
-
     fn actor_id(&self) -> &ActorId {
-        self.msg_source.get_or_init(msg::source)
+        self.msg_source
+            .get_or_init(|| msg::source().as_ref().into())
     }
 }

--- a/runtimes/rtl/Cargo.toml
+++ b/runtimes/rtl/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sails-rtl"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+hashbrown.workspace = true
+parity-scale-codec = { workspace = true, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }

--- a/runtimes/rtl/src/lib.rs
+++ b/runtimes/rtl/src/lib.rs
@@ -1,0 +1,11 @@
+#![no_std]
+
+pub use prelude::*;
+pub use types::*;
+
+pub mod prelude;
+pub mod types;
+
+pub trait ExecContext {
+    fn actor_id(&self) -> &ActorId;
+}

--- a/runtimes/rtl/src/prelude.rs
+++ b/runtimes/rtl/src/prelude.rs
@@ -1,0 +1,51 @@
+extern crate alloc;
+
+pub use alloc::{
+    borrow,
+    borrow::ToOwned,
+    boxed,
+    boxed::Box,
+    fmt, format, rc, str, string,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+pub use core::{
+    any, array, ascii, assert_eq, assert_ne, cell, char, clone, cmp, convert, debug_assert,
+    debug_assert_eq, debug_assert_ne, default, future, hash, hint, iter, marker, matches, mem, num,
+    ops, option, panic, pin, prelude::rust_2021::*, primitive, ptr, result, slice, task, time,
+    todo, unimplemented, unreachable, write, writeln,
+};
+
+/// Collection types.
+///
+/// See [`alloc::collections`] & [`hashbrown`].
+///
+/// [`alloc::collections`]: ::alloc::collections
+pub mod collections {
+    extern crate alloc;
+
+    pub use ::hashbrown::{hash_map, hash_set, HashMap, HashSet};
+    pub use alloc::collections::*;
+
+    /// Reexports from [`hashbrown`].
+    pub mod hashbrown {
+        pub use ::hashbrown::{Equivalent, TryReserveError};
+    }
+}
+/// Utilities related to FFI bindings.
+///
+/// See [`alloc::ffi`] & [`core::ffi`].
+///
+/// [`alloc::ffi`]: ::alloc::ffi
+pub mod ffi {
+    extern crate alloc;
+
+    pub use alloc::ffi::*;
+    pub use core::ffi::*;
+}
+
+// Reexports from third-party libraries
+
+pub use parity_scale_codec::{Decode, Encode, EncodeLike};
+pub use scale_info::{self, TypeInfo};

--- a/runtimes/rtl/src/types.rs
+++ b/runtimes/rtl/src/types.rs
@@ -1,0 +1,33 @@
+use crate::prelude::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode, TypeInfo)]
+pub struct ActorId([u8; 32]);
+
+impl From<[u8; 32]> for ActorId {
+    fn from(arr: [u8; 32]) -> Self {
+        Self(arr)
+    }
+}
+
+// Can panic if slice is not 32 bytes long
+impl From<&[u8]> for ActorId {
+    fn from(slice: &[u8]) -> Self {
+        let mut arr = [0; 32];
+        arr.copy_from_slice(slice);
+        Self(arr)
+    }
+}
+
+impl From<u64> for ActorId {
+    fn from(v: u64) -> Self {
+        let mut arr = [0u8; 32];
+        arr[0..8].copy_from_slice(&v.to_le_bytes()[..]);
+        Self(arr)
+    }
+}
+
+impl AsRef<[u8]> for ActorId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}

--- a/runtimes/rtl/src/types.rs
+++ b/runtimes/rtl/src/types.rs
@@ -22,11 +22,78 @@ impl From<u64> for ActorId {
     fn from(v: u64) -> Self {
         let mut arr = [0u8; 32];
         arr[0..8].copy_from_slice(&v.to_le_bytes()[..]);
+        arr[31] = 'A' as u8;
         Self(arr)
     }
 }
 
 impl AsRef<[u8]> for ActorId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode, TypeInfo)]
+pub struct MessageId([u8; 32]);
+
+impl From<[u8; 32]> for MessageId {
+    fn from(arr: [u8; 32]) -> Self {
+        Self(arr)
+    }
+}
+
+// Can panic if slice is not 32 bytes long
+impl From<&[u8]> for MessageId {
+    fn from(slice: &[u8]) -> Self {
+        let mut arr = [0; 32];
+        arr.copy_from_slice(slice);
+        Self(arr)
+    }
+}
+
+impl From<u64> for MessageId {
+    fn from(v: u64) -> Self {
+        let mut arr = [0u8; 32];
+        arr[0..8].copy_from_slice(&v.to_le_bytes()[..]);
+        arr[31] = 'M' as u8;
+        Self(arr)
+    }
+}
+
+impl AsRef<[u8]> for MessageId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode, TypeInfo)]
+pub struct CodeId([u8; 32]);
+
+impl From<[u8; 32]> for CodeId {
+    fn from(arr: [u8; 32]) -> Self {
+        Self(arr)
+    }
+}
+
+// Can panic if slice is not 32 bytes long
+impl From<&[u8]> for CodeId {
+    fn from(slice: &[u8]) -> Self {
+        let mut arr = [0; 32];
+        arr.copy_from_slice(slice);
+        Self(arr)
+    }
+}
+
+impl From<u64> for CodeId {
+    fn from(v: u64) -> Self {
+        let mut arr = [0u8; 32];
+        arr[0..8].copy_from_slice(&v.to_le_bytes()[..]);
+        arr[31] = 'C' as u8;
+        Self(arr)
+    }
+}
+
+impl AsRef<[u8]> for CodeId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }

--- a/runtimes/rtl/src/types.rs
+++ b/runtimes/rtl/src/types.rs
@@ -22,7 +22,7 @@ impl From<u64> for ActorId {
     fn from(v: u64) -> Self {
         let mut arr = [0u8; 32];
         arr[0..8].copy_from_slice(&v.to_le_bytes()[..]);
-        arr[31] = 'A' as u8;
+        arr[31] = b'A';
         Self(arr)
     }
 }
@@ -55,7 +55,7 @@ impl From<u64> for MessageId {
     fn from(v: u64) -> Self {
         let mut arr = [0u8; 32];
         arr[0..8].copy_from_slice(&v.to_le_bytes()[..]);
-        arr[31] = 'M' as u8;
+        arr[31] = b'M';
         Self(arr)
     }
 }
@@ -88,7 +88,7 @@ impl From<u64> for CodeId {
     fn from(v: u64) -> Self {
         let mut arr = [0u8; 32];
         arr[0..8].copy_from_slice(&v.to_le_bytes()[..]);
-        arr[31] = 'C' as u8;
+        arr[31] = b'C';
         Self(arr)
     }
 }


### PR DESCRIPTION
This is a step towards resolving #85 
The PR introduces build-in types for `ActorId`, `MessageId` and `CodeId` as well as a sort of runtime crates as an analogy of C runtime library.
The `sails-rtl` crate incorporates base primitive types, re-exports for common types and some abstractions which are implemented in a more specific crates.
The `sails-rtl-gstd` crate is basically about re-exporting `gstd` types + implementing abstractions from the `sails-rtl` crate using means provide by `gstd`