### PR TITLE
build(idl-parser): Remove ignored options

### DIFF
--- a/idlparser/Cargo.toml
+++ b/idlparser/Cargo.toml
@@ -8,10 +8,6 @@ license.workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-lto = true
-opt-level = 's'
-
 [dependencies]
 lalrpop-util.workspace = true
 logos.workspace = true


### PR DESCRIPTION
The options are:
1. ignored as they are not in the root of the workspace
2. doesn't give any benefit