### PR TITLE
refactor(macros): Generate service dispatching code as service methods

### DIFF
--- a/examples/puppeteer/wasm/src/lib.rs
+++ b/examples/puppeteer/wasm/src/lib.rs
@@ -3,7 +3,7 @@
 use core::ptr::addr_of_mut;
 use gstd::{boxed::Box, msg};
 use puppeteer_app::puppet::Client;
-use puppeteer_app::{requests as service_requests, Puppeteer};
+use puppeteer_app::Puppeteer;
 use sails_sender::GStdSender;
 
 static mut SERVICE: Option<Puppeteer> = None;
@@ -21,6 +21,6 @@ fn service() -> &'static mut Puppeteer {
 #[gstd::async_main]
 async fn main() {
     let input_bytes = msg::load_bytes().expect("Failed to read input");
-    let output_bytes = service_requests::process(service(), &input_bytes).await;
+    let output_bytes = service().handle(&input_bytes).await;
     msg::reply_bytes(output_bytes, 0).expect("Failed to send output");
 }

--- a/examples/rmrk/catalog/app/src/lib.rs
+++ b/examples/rmrk/catalog/app/src/lib.rs
@@ -44,13 +44,12 @@ pub mod wasm_main {
     use super::wasm::PROGRAM;
     use super::*;
     use sails_rtl_gstd::{gstd, gstd::msg};
-    use services::requests;
 
     #[gstd::async_main] // Make async optional
     async fn main() {
         let input_bytes = msg::load_bytes().expect("Failed to read input");
         let mut catalog = unsafe { PROGRAM.as_ref().unwrap() }.catalog();
-        let output_bytes = requests::process(&mut catalog, &input_bytes).await;
+        let output_bytes = catalog.handle(&input_bytes).await;
         msg::reply_bytes(output_bytes, 0).expect("Failed to send output");
     }
 }

--- a/examples/rmrk/resource/app/src/lib.rs
+++ b/examples/rmrk/resource/app/src/lib.rs
@@ -51,13 +51,12 @@ pub mod wasm_main {
     use super::wasm::PROGRAM;
     use super::*;
     use sails_rtl_gstd::{gstd, gstd::msg};
-    use services::requests;
 
     #[gstd::async_main]
     async fn main() {
         let input_bytes = msg::load_bytes().expect("Failed to read input");
         let mut resource_storage = unsafe { PROGRAM.as_ref().unwrap() }.resource_storage();
-        let output_bytes = requests::process(&mut resource_storage, &input_bytes).await;
+        let output_bytes = resource_storage.handle(&input_bytes).await;
         msg::reply_bytes(output_bytes, 0).expect("Failed to send output");
     }
 }

--- a/examples/this-that-svc/wasm/src/lib.rs
+++ b/examples/this-that-svc/wasm/src/lib.rs
@@ -2,7 +2,7 @@
 
 use core::ptr::addr_of_mut;
 use gstd::msg;
-use this_that_svc_app::{requests as service_requests, MyService};
+use this_that_svc_app::MyService;
 
 static mut MY_SERVICE: MyService = MyService::new();
 
@@ -13,6 +13,6 @@ fn my_service() -> &'static mut MyService {
 #[gstd::async_main]
 async fn main() {
     let input_bytes = msg::load_bytes().expect("Failed to read input");
-    let output_bytes = service_requests::process(my_service(), &input_bytes).await;
+    let output_bytes = my_service().handle(&input_bytes).await;
     msg::reply_bytes(output_bytes, 0).expect("Failed to send output");
 }

--- a/macros/core/src/shared.rs
+++ b/macros/core/src/shared.rs
@@ -1,15 +1,12 @@
 use proc_macro_error::abort;
 use quote::ToTokens;
 use syn::{
-    spanned::Spanned, FnArg, Ident, ItemImpl, Pat, PathArguments, Receiver, ReturnType, Signature,
-    Type, TypePath, WhereClause,
+    spanned::Spanned, FnArg, Ident, ItemImpl, Pat, Receiver, ReturnType, Signature, Type, TypePath,
 };
 
 /// A struct that represents the type of an `impl` block.
 pub(crate) struct ImplType<'a> {
     path: &'a TypePath,
-    args: &'a PathArguments,
-    constraints: Option<&'a WhereClause>,
 }
 
 impl<'a> ImplType<'a> {
@@ -24,25 +21,11 @@ impl<'a> ImplType<'a> {
                 impl_type.to_token_stream()
             )
         };
-        let args = &path.path.segments.last().unwrap().arguments;
-        let constraints = r#impl.generics.where_clause.as_ref();
-        Self {
-            path,
-            args,
-            constraints,
-        }
+        Self { path }
     }
 
     pub(crate) fn path(&self) -> &TypePath {
         self.path
-    }
-
-    pub(crate) fn args(&self) -> &PathArguments {
-        self.args
-    }
-
-    pub(crate) fn constraints(&self) -> Option<&WhereClause> {
-        self.constraints
     }
 }
 

--- a/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works.snap
+++ b/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works.snap
@@ -9,59 +9,57 @@ impl SomeService {
     pub fn this(&self, p1: bool) -> bool {
         p1
     }
-}
-#[derive(Decode, TypeInfo)]
-pub struct DoThisParams {
-    p1: u32,
-    p2: String,
-}
-#[derive(Decode, TypeInfo)]
-pub struct ThisParams {
-    p1: bool,
-}
-pub mod meta {
-    use super::*;
-    #[derive(TypeInfo)]
-    pub enum CommandsMeta {
-        DoThis(DoThisParams, u32),
-    }
-    #[derive(TypeInfo)]
-    pub enum QueriesMeta {
-        This(ThisParams, bool),
-    }
-    pub struct ServiceMeta;
-    impl sails_service_meta::ServiceMeta for ServiceMeta {
-        type Commands = CommandsMeta;
-        type Queries = QueriesMeta;
-    }
-}
-pub mod requests {
-    use super::*;
-    pub async fn process(service: &mut SomeService, mut input: &[u8]) -> Vec<u8> {
+    pub async fn handle(&mut self, mut input: &[u8]) -> Vec<u8> {
         let invocation_path = "DoThis".encode();
         if input.starts_with(&invocation_path) {
-            let output = do_this(service, &input[invocation_path.len()..]).await;
+            let output = self.__do_this(&input[invocation_path.len()..]).await;
             return [invocation_path, output].concat();
         }
         let invocation_path = "This".encode();
         if input.starts_with(&invocation_path) {
-            let output = this(service, &input[invocation_path.len()..]).await;
+            let output = self.__this(&input[invocation_path.len()..]).await;
             return [invocation_path, output].concat();
         }
         let invocation_path = String::decode(&mut input)
             .expect("Failed to decode invocation path");
         panic!("Unknown request: {}", invocation_path);
     }
-    async fn do_this(service: &mut SomeService, mut input: &[u8]) -> Vec<u8> {
-        let request = DoThisParams::decode(&mut input)
+    async fn __do_this(&mut self, mut input: &[u8]) -> Vec<u8> {
+        let request = __DoThisParams::decode(&mut input)
             .expect("Failed to decode request");
-        let result = service.do_this(request.p1, request.p2).await;
+        let result = self.do_this(request.p1, request.p2).await;
         return result.encode();
     }
-    async fn this(service: &SomeService, mut input: &[u8]) -> Vec<u8> {
-        let request = ThisParams::decode(&mut input).expect("Failed to decode request");
-        let result = service.this(request.p1);
+    async fn __this(&self, mut input: &[u8]) -> Vec<u8> {
+        let request = __ThisParams::decode(&mut input)
+            .expect("Failed to decode request");
+        let result = self.this(request.p1);
         return result.encode();
+    }
+}
+#[derive(Decode, TypeInfo)]
+pub struct __DoThisParams {
+    p1: u32,
+    p2: String,
+}
+#[derive(Decode, TypeInfo)]
+pub struct __ThisParams {
+    p1: bool,
+}
+pub mod meta {
+    use super::*;
+    #[derive(TypeInfo)]
+    pub enum CommandsMeta {
+        DoThis(__DoThisParams, u32),
+    }
+    #[derive(TypeInfo)]
+    pub enum QueriesMeta {
+        This(__ThisParams, bool),
+    }
+    pub struct ServiceMeta;
+    impl sails_service_meta::ServiceMeta for ServiceMeta {
+        type Commands = CommandsMeta;
+        type Queries = QueriesMeta;
     }
 }
 

--- a/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works_for_lifetimes_and_generics.snap
+++ b/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works_for_lifetimes_and_generics.snap
@@ -9,14 +9,30 @@ where
     pub fn do_this(&mut self) -> u32 {
         42
     }
+    pub async fn handle(&mut self, mut input: &[u8]) -> Vec<u8> {
+        let invocation_path = "DoThis".encode();
+        if input.starts_with(&invocation_path) {
+            let output = self.__do_this(&input[invocation_path.len()..]).await;
+            return [invocation_path, output].concat();
+        }
+        let invocation_path = String::decode(&mut input)
+            .expect("Failed to decode invocation path");
+        panic!("Unknown request: {}", invocation_path);
+    }
+    async fn __do_this(&mut self, mut input: &[u8]) -> Vec<u8> {
+        let request = __DoThisParams::decode(&mut input)
+            .expect("Failed to decode request");
+        let result = self.do_this();
+        return result.encode();
+    }
 }
 #[derive(Decode, TypeInfo)]
-pub struct DoThisParams {}
+pub struct __DoThisParams {}
 pub mod meta {
     use super::*;
     #[derive(TypeInfo)]
     pub enum CommandsMeta {
-        DoThis(DoThisParams, u32),
+        DoThis(__DoThisParams, u32),
     }
     #[derive(TypeInfo)]
     pub enum QueriesMeta {}
@@ -24,37 +40,6 @@ pub mod meta {
     impl sails_service_meta::ServiceMeta for ServiceMeta {
         type Commands = CommandsMeta;
         type Queries = QueriesMeta;
-    }
-}
-pub mod requests {
-    use super::*;
-    pub async fn process<'a, 'b, T>(
-        service: &mut SomeService<'a, 'b, T>,
-        mut input: &[u8],
-    ) -> Vec<u8>
-    where
-        T: Clone,
-    {
-        let invocation_path = "DoThis".encode();
-        if input.starts_with(&invocation_path) {
-            let output = do_this(service, &input[invocation_path.len()..]).await;
-            return [invocation_path, output].concat();
-        }
-        let invocation_path = String::decode(&mut input)
-            .expect("Failed to decode invocation path");
-        panic!("Unknown request: {}", invocation_path);
-    }
-    async fn do_this<'a, 'b, T>(
-        service: &mut SomeService<'a, 'b, T>,
-        mut input: &[u8],
-    ) -> Vec<u8>
-    where
-        T: Clone,
-    {
-        let request = DoThisParams::decode(&mut input)
-            .expect("Failed to decode request");
-        let result = service.do_this();
-        return result.encode();
     }
 }
 

--- a/macros/tests/ui/gservice_works.rs
+++ b/macros/tests/ui/gservice_works.rs
@@ -36,7 +36,7 @@ async fn main() {
         .encode(),
     ]
     .concat();
-    let output = requests::process(&mut my_service, &input).await;
+    let output = my_service.handle(&input).await;
     let mut output = output.as_slice();
 
     let func_name = String::decode(&mut output).unwrap();

--- a/macros/tests/ui/gservice_works_for_lifecycles_and_generics.rs
+++ b/macros/tests/ui/gservice_works_for_lifecycles_and_generics.rs
@@ -23,7 +23,7 @@ async fn main() {
 
     let mut my_service = MyService::<'_, String> { _a: PhantomData };
 
-    let output = requests::process(&mut my_service, &DO_THIS.encode()).await;
+    let output = my_service.handle(&DO_THIS.encode()).await;
     let mut output = output.as_slice();
 
     let func_name = String::decode(&mut output).unwrap();


### PR DESCRIPTION
This PR refactors generation of dispatching code for service. Instead of generating them as free functions of newly introduced module, we generate them as methods of the service itself. It will help to generate program dispatching code in the scope of #86 