### PR TITLE
feat(idl-parser): Introduce 'constructor' block

### DIFF
--- a/client-gen/src/generator.rs
+++ b/client-gen/src/generator.rs
@@ -109,13 +109,13 @@ impl<'ast> Visitor<'ast> for ServiceGenerator {
         self.code.push_str("}\n");
     }
 
-    fn visit_func(&mut self, func: &'ast Func) {
+    fn visit_service_func(&mut self, func: &'ast ServiceFunc) {
         let mutability = if func.is_query() { "" } else { "mut" };
         let name = func.name().to_case(Case::Snake);
 
         self.code
             .push_str(&format!("fn {}(&{} self,", name, mutability));
-        visitor::accept_func(func, self);
+        visitor::accept_service_func(func, self);
         self.code.push_str(";\n");
     }
 
@@ -171,7 +171,7 @@ impl<'ast> Visitor<'ast> for ClientGenerator {
         self.code.push_str("}\n");
     }
 
-    fn visit_func(&mut self, func: &'ast Func) {
+    fn visit_service_func(&mut self, func: &'ast ServiceFunc) {
         let mutability = if func.is_query() { "" } else { "mut" };
         let fn_name = func.name();
 
@@ -181,7 +181,7 @@ impl<'ast> Visitor<'ast> for ClientGenerator {
             mutability
         ));
 
-        visitor::accept_func(func, self);
+        visitor::accept_service_func(func, self);
 
         self.code.push_str("{\n");
 
@@ -425,11 +425,6 @@ mod tests {
     #[test]
     fn test_basic_works() {
         let idl = r"
-            service {
-                DoThis: (p1: u32, p2: MyParam) -> u16;
-                DoThat: (p1: struct { u8, u32 }) -> u8;
-            };
-
             type MyParam = struct {
                 f1: u32,
                 f2: vec str,
@@ -442,6 +437,11 @@ mod tests {
                 Variant3: struct { u32 },
                 Variant4: struct { u8, u32 },
                 Variant5: struct { f1: str, f2: vec u8 },
+            };
+
+            service {
+                DoThis: (p1: u32, p2: MyParam) -> u16;
+                DoThat: (p1: struct { u8, u32 }) -> u8;
             };
         ";
 

--- a/client-gen/src/lib.rs
+++ b/client-gen/src/lib.rs
@@ -49,14 +49,14 @@ mod tests {
             Six: struct { u32 },
         };
 
+        type T = enum { One };
+
         service {
             DoThis : (p1: u32, p2: str, p3: struct { opt str, u8 }, p4: ThisThatSvcAppTupleStruct) -> struct { str, u32 };
             DoThat : (param: ThisThatSvcAppDoThatParam) -> result (struct { str, u32 }, struct { str });
             query This : (v1: vec u16) -> u32;
             query That : (v1: null) -> result (str, str);
         };
-
-        type T = enum { One }
         "#;
         let program = sails_idlparser::ast::parse_idl(IDL).expect("parse IDL");
 

--- a/idlparser/src/ffi/ast/mod.rs
+++ b/idlparser/src/ffi/ast/mod.rs
@@ -31,12 +31,24 @@ pub unsafe extern "C" fn free_program(program: *mut Program) {
 pub type Program = ast::Program;
 
 #[repr(C)]
+pub struct Ctor {
+    raw_ptr: Ptr,
+}
+
+#[repr(C)]
+pub struct CtorFunc {
+    raw_ptr: Ptr,
+    name_ptr: *const u8,
+    name_len: u32,
+}
+
+#[repr(C)]
 pub struct Service {
     raw_ptr: Ptr,
 }
 
 #[repr(C)]
-pub struct Func {
+pub struct ServiceFunc {
     raw_ptr: Ptr,
     name_ptr: *const u8,
     name_len: u32,

--- a/idlparser/src/grammar.lalrpop
+++ b/idlparser/src/grammar.lalrpop
@@ -18,6 +18,7 @@ extern {
         ":" => Token::Colon,
         "," => Token::Comma,
         "->" => Token::Arrow,
+        "constructor" => Token::Ctor,
         "service" => Token::Service,
         "query" => Token::Query,
         "type" => Token::Type,
@@ -34,22 +35,30 @@ extern {
 }
 
 pub Program: Program = {
-    <types1: (<Separated<Type, ";">> ";")?> <service: Service> <types2: (";" <Separated<Type, ";">>)?> =>
+    <types: (<Separated<Type, ";">> ";")?> <ctor: (Ctor ";")?> <service: Service> ";"? =>
         Program::new(
+            ctor.map(|c| c.0),
             service,
-            types1.unwrap_or_default().into_iter()
-                .chain(types2.unwrap_or_default().into_iter())
-                .collect(),
+            types.unwrap_or_default(),
         ),
 }
 
-Service: Service = {
-    "service" "{" <Separated<Func, ";">> "}" => Service::new(<>),
+Ctor: Ctor = {
+    "constructor" "{" <Separated<CtorFunc, ";">> "}" => Ctor::new(<>),
 }
 
-Func: Func = {
+CtorFunc : CtorFunc = {
+    <name: "id"> ":" "(" <params: Separated<FuncParam, ",">> ")" =>
+        CtorFunc::new(name, params),
+}
+
+Service: Service = {
+    "service" "{" <Separated<ServiceFunc, ";">> "}" => Service::new(<>),
+}
+
+ServiceFunc: ServiceFunc = {
     <query: "query"?> <name: "id"> ":" "(" <params: Separated<FuncParam, ",">> ")" "->" <output: TypeDecl> =>
-        Func::new(name, params, output, query.is_some()),
+        ServiceFunc::new(name, params, output, query.is_some()),
 }
 
 FuncParam: FuncParam = {

--- a/idlparser/src/lexer.rs
+++ b/idlparser/src/lexer.rs
@@ -64,6 +64,8 @@ pub(crate) enum Token {
     Struct,
     #[token("enum")]
     Enum,
+    #[token("constructor")]
+    Ctor,
     #[token("service")]
     Service,
     #[token("query")]

--- a/js/src/parser/parser.ts
+++ b/js/src/parser/parser.ts
@@ -180,12 +180,12 @@ export class WasmParser {
           $._exports.accept_enum_variant(enum_variant_ptr, id);
         },
         visit_ctor: (_, ctor_ptr: number) => {
-          // TODO: Behaviour should be defined
-          $._exports.accept_ctor(ctor_ptr, 0);
+          // TODO: Behaviour should be defined (#115). Stop traversing further
+          // $._exports.accept_ctor(ctor_ptr, 0);
         },
         visit_ctor_func: (_, func_ptr: number) => {
-          // TODO: Behaviour should be defined
-          $._exports.accept_ctor_func(func_ptr, 0);
+          // TODO: Behaviour should be defined (#115). Stop traversing further
+          //$._exports.accept_ctor_func(func_ptr, 0);
         },
         visit_service: (_, service_ptr: number) => {
           $._program.addService(new Service(service_ptr, $._memory));

--- a/js/src/parser/parser.ts
+++ b/js/src/parser/parser.ts
@@ -27,8 +27,10 @@ interface ParserInstance extends WebAssembly.Instance {
     parse_idl: (idl_ptr: number, idl_len: number) => number;
     free_program: (program_ptr: number) => void;
     accept_program: (program_ptr: number, ctx: number) => void;
+    accept_ctor: (ctor_ptr: number, ctx: number) => void;
+    accept_ctor_func: (func_ptr: number, ctx: number) => void;
     accept_service: (service_ptr: number, ctx: number) => void;
-    accept_func: (func_ptr: number, ctx: number) => void;
+    accept_service_func: (func_ptr: number, ctx: number) => void;
     accept_func_param: (func_param_ptr: number, ctx: number) => void;
     accept_type: (type_ptr: number, ctx: number) => void;
     accept_type_decl: (type_decl_ptr: number, ctx: number) => void;
@@ -177,15 +179,23 @@ export class WasmParser {
           $._program.addContext(id, variant);
           $._exports.accept_enum_variant(enum_variant_ptr, id);
         },
+        visit_ctor: (_, ctor_ptr: number) => {
+          // TODO: Behaviour should be defined
+          $._exports.accept_ctor(ctor_ptr, 0);
+        },
+        visit_ctor_func: (_, func_ptr: number) => {
+          // TODO: Behaviour should be defined
+          $._exports.accept_ctor_func(func_ptr, 0);
+        },
         visit_service: (_, service_ptr: number) => {
           $._program.addService(new Service(service_ptr, $._memory));
           $._exports.accept_service(service_ptr, 0);
         },
-        visit_func: (_, func_ptr: number) => {
+        visit_service_func: (_, func_ptr: number) => {
           const func = new Func(func_ptr, $._memory);
           $._program.service.addFunc(func);
           $._program.addContext(func.rawPtr, func);
-          $._exports.accept_func(func_ptr, func.rawPtr);
+          $._exports.accept_service_func(func_ptr, func.rawPtr);
         },
         visit_func_param: (ctx: number, func_param_ptr: number) => {
           const param = new FuncParam(func_param_ptr, $._memory);


### PR DESCRIPTION
Resolves #112  .

This PR introduces optional `constructor` block in program IDL. The block can contain possible methods/functions which can be used for constructing a program.
In order to simplify IDL grammar for the time being, IDL structure has been made stricter. It requires specific order of the blocks used:
- any number of `type` blocks
- optional `constructor` block
- required `service` block
Later it can be reconsidered and more flexibility provided