### PR TITLE
fix(macros): Remove unnecessary memory allocations during service invocation routing

### DIFF
--- a/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works.snap
+++ b/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works.snap
@@ -10,15 +10,23 @@ impl SomeService {
         p1
     }
     pub async fn handle(&mut self, mut input: &[u8]) -> Vec<u8> {
-        let invocation_path = "DoThis".encode();
-        if input.starts_with(&invocation_path) {
-            let output = self.__do_this(&input[invocation_path.len()..]).await;
-            return [invocation_path, output].concat();
+        if input.starts_with(&[24u8, 68u8, 111u8, 84u8, 104u8, 105u8, 115u8]) {
+            let output = self.__do_this(&input[7usize..]).await;
+            static INVOCATION_ROUTE: [u8; 7usize] = [
+                24u8,
+                68u8,
+                111u8,
+                84u8,
+                104u8,
+                105u8,
+                115u8,
+            ];
+            return [INVOCATION_ROUTE.as_ref(), &output].concat();
         }
-        let invocation_path = "This".encode();
-        if input.starts_with(&invocation_path) {
-            let output = self.__this(&input[invocation_path.len()..]).await;
-            return [invocation_path, output].concat();
+        if input.starts_with(&[16u8, 84u8, 104u8, 105u8, 115u8]) {
+            let output = self.__this(&input[5usize..]).await;
+            static INVOCATION_ROUTE: [u8; 5usize] = [16u8, 84u8, 104u8, 105u8, 115u8];
+            return [INVOCATION_ROUTE.as_ref(), &output].concat();
         }
         let invocation_path = String::decode(&mut input)
             .expect("Failed to decode invocation path");

--- a/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works_for_lifetimes_and_generics.snap
+++ b/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works_for_lifetimes_and_generics.snap
@@ -10,10 +10,18 @@ where
         42
     }
     pub async fn handle(&mut self, mut input: &[u8]) -> Vec<u8> {
-        let invocation_path = "DoThis".encode();
-        if input.starts_with(&invocation_path) {
-            let output = self.__do_this(&input[invocation_path.len()..]).await;
-            return [invocation_path, output].concat();
+        if input.starts_with(&[24u8, 68u8, 111u8, 84u8, 104u8, 105u8, 115u8]) {
+            let output = self.__do_this(&input[7usize..]).await;
+            static INVOCATION_ROUTE: [u8; 7usize] = [
+                24u8,
+                68u8,
+                111u8,
+                84u8,
+                104u8,
+                105u8,
+                115u8,
+            ];
+            return [INVOCATION_ROUTE.as_ref(), &output].concat();
         }
         let invocation_path = String::decode(&mut input)
             .expect("Failed to decode invocation path");


### PR DESCRIPTION
Resolves #72  .

Unnecessary memory allocations and runtime route encoding has been removed by this PR.
As it comes to using a hash in lieu of bytes, we might return to this later when we have some means allowing any node event listener like indexer to obtain an IDL for a program of interest and compute hash on its side so it can match responses with a specific methods.