### PR TITLE
feat(idl-parser): Introduce service event parsing

### DIFF
--- a/idlparser/src/ast/mod.rs
+++ b/idlparser/src/ast/mod.rs
@@ -80,15 +80,20 @@ impl CtorFunc {
 #[derive(Debug, PartialEq, Clone)]
 pub struct Service {
     funcs: Vec<ServiceFunc>,
+    events: Vec<ServiceEvent>,
 }
 
 impl Service {
-    pub(crate) fn new(funcs: Vec<ServiceFunc>) -> Self {
-        Self { funcs }
+    pub(crate) fn new(funcs: Vec<ServiceFunc>, events: Vec<ServiceEvent>) -> Self {
+        Self { funcs, events }
     }
 
     pub fn funcs(&self) -> &[ServiceFunc] {
         &self.funcs
+    }
+
+    pub fn events(&self) -> &[ServiceEvent] {
+        &self.events
     }
 }
 
@@ -132,6 +137,9 @@ impl ServiceFunc {
         self.is_query
     }
 }
+
+/// A structure describing one of service events
+pub type ServiceEvent = EnumVariant;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct FuncParam {
@@ -358,6 +366,13 @@ mod tests {
             DoThat : (param: ThisThatSvcAppDoThatParam) -> result (struct { str, u32 }, struct { str });
             query This : (v1: vec u16) -> u32;
             query That : (v1: null) -> result (str, str);
+
+            events {
+                ThisDone;
+                ThatDone: u32;
+                SomethingHappened: struct { str, u32 };
+                SomethingDone: ThisThatSvcAppManyVariants;
+            }
           };
         ";
 
@@ -366,6 +381,7 @@ mod tests {
         assert_eq!(program.types().len(), 3);
         assert_eq!(program.ctor().unwrap().funcs().len(), 1);
         assert_eq!(program.service().funcs().len(), 4);
+        assert_eq!(program.service().events().len(), 4);
 
         //println!("ast: {:#?}", program);
     }

--- a/idlparser/src/ast/visitor.rs
+++ b/idlparser/src/ast/visitor.rs
@@ -55,6 +55,10 @@ pub trait Visitor<'ast> {
         accept_service_func(func, self);
     }
 
+    fn visit_service_event(&mut self, event: &'ast ServiceEvent) {
+        accept_service_event(event, self);
+    }
+
     fn visit_func_param(&mut self, func_param: &'ast FuncParam) {
         accept_func_param(func_param, self);
     }
@@ -116,6 +120,13 @@ pub fn accept_service_func<'ast>(
         visitor.visit_func_param(param);
     }
     visitor.visit_func_output(func.output());
+}
+
+pub fn accept_service_event<'ast>(
+    event: &'ast ServiceEvent,
+    visitor: &mut (impl Visitor<'ast> + ?Sized),
+) {
+    accept_enum_variant(event, visitor)
 }
 
 pub fn accept_func_param<'ast>(
@@ -226,7 +237,7 @@ mod tests {
     fn accept_program_works() {
         let program = Program::new(
             Some(Ctor::new(vec![])),
-            Service::new(vec![]),
+            Service::new(vec![], vec![]),
             vec![
                 Type::new("Type1".into(), TypeDef::Struct(StructDef::new(vec![]))),
                 Type::new("Type2".into(), TypeDef::Enum(EnumDef::new(vec![]))),

--- a/idlparser/src/ffi/ast/mod.rs
+++ b/idlparser/src/ffi/ast/mod.rs
@@ -55,6 +55,8 @@ pub struct ServiceFunc {
     is_query: bool,
 }
 
+pub type ServiceEvent = EnumVariant;
+
 #[repr(C)]
 pub struct FuncParam {
     raw_ptr: Ptr,

--- a/idlparser/src/grammar.lalrpop
+++ b/idlparser/src/grammar.lalrpop
@@ -20,6 +20,7 @@ extern {
         "->" => Token::Arrow,
         "constructor" => Token::Ctor,
         "service" => Token::Service,
+        "events" => Token::Events,
         "query" => Token::Query,
         "type" => Token::Type,
         "struct" => Token::Struct,
@@ -53,7 +54,8 @@ CtorFunc : CtorFunc = {
 }
 
 Service: Service = {
-    "service" "{" <Separated<ServiceFunc, ";">> "}" => Service::new(<>),
+    "service" "{" <funcs: Separated<ServiceFunc, ";">> <events: ("events" "{" <Separated<EnumVariant, ";">> "}")?> "}" =>
+        Service::new(funcs, events.unwrap_or_default()),
 }
 
 ServiceFunc: ServiceFunc = {

--- a/idlparser/src/lexer.rs
+++ b/idlparser/src/lexer.rs
@@ -68,6 +68,8 @@ pub(crate) enum Token {
     Ctor,
     #[token("service")]
     Service,
+    #[token("events")]
+    Events,
     #[token("query")]
     Query,
     #[token("type")]

--- a/js/src/parser/parser.ts
+++ b/js/src/parser/parser.ts
@@ -201,6 +201,9 @@ export class WasmParser {
           $._program.addContext(func.rawPtr, func);
           $._exports.accept_service_func(func_ptr, func.rawPtr);
         },
+        visit_service_event: (_, event_ptr: number) => {
+          // TODO
+        },
         visit_func_param: (ctx: number, func_param_ptr: number) => {
           const param = new FuncParam(func_param_ptr, $._memory);
           const func = $._program.getContext(ctx);


### PR DESCRIPTION
This PR introduces support for parsing `events` sub-section of the `service` one. The sub-section denotes events possibly emitted by a service. In general, the format of the sub-section matches to `enum` definition, i.e. each `event` line looks exactly the same as `enum variant` one.