### PR TITLE
feat(idl-gen, macro): Implement generation of the events section in idl

### DIFF
--- a/examples/rmrk/resource/wasm/rmrk-resource.idl
+++ b/examples/rmrk/resource/wasm/rmrk-resource.idl
@@ -43,4 +43,9 @@ service {
   AddPartToResource : (resource_id: u8, part_id: u32) -> result (u32, Error);
   AddResourceEntry : (resource_id: u8, resource: Resource) -> result (struct { u8, Resource }, Error);
   query Resource : (resource_id: u8) -> result (Resource, Error);
+
+  events {
+    ResourceAdded: struct { resource_id: u8 };
+    PartAdded: struct { resource_id: u8, part_id: u32 };
+  }
 }

--- a/idl-meta/src/lib.rs
+++ b/idl-meta/src/lib.rs
@@ -25,11 +25,13 @@ use scale_info::MetaType;
 pub trait ServiceMeta {
     fn commands() -> MetaType;
     fn queries() -> MetaType;
+    fn events() -> MetaType;
 }
 
 pub struct AnyServiceMeta {
     commands: MetaType,
     queries: MetaType,
+    events: MetaType,
 }
 
 impl AnyServiceMeta {
@@ -37,6 +39,7 @@ impl AnyServiceMeta {
         Self {
             commands: S::commands(),
             queries: S::queries(),
+            events: S::events(),
         }
     }
 
@@ -46,6 +49,10 @@ impl AnyServiceMeta {
 
     pub fn queries(&self) -> &MetaType {
         &self.queries
+    }
+
+    pub fn events(&self) -> &MetaType {
+        &self.events
     }
 }
 

--- a/idlgen/hbs/idl.hbs
+++ b/idlgen/hbs/idl.hbs
@@ -19,4 +19,18 @@ service {
 {{#each queries}}
   query {{./[0]}} : ({{#each ./[1]}}{{#if @index}}, {{/if}}{{name}}: {{{lookup @root/type_names type}}}{{/each}}) -> {{{lookup @root/type_names ./[2]}}};
 {{/each}}
+{{#if (len events)}}
+
+  events {
+  {{#each events}}
+    {{name}}
+    {{~#if fields.[1]}}: struct { {{#each fields~}} {{#if @index}}, {{/if}}{{#if name}}{{name}}: {{/if}}{{{lookup @root/type_names type}}}{{/each}} }
+    {{~else}}
+	    {{~#if fields.[0]}}: {{#with fields.[0]}} {{~#if name~}} struct { {{name}}: {{{lookup @root/type_names type}}} } {{~else~}} {{{lookup @root/type_names type}}} {{~/if}}{{/with}}
+      {{~/if}}
+    {{/if~}}
+    ;
+  {{/each}}
+  }
+{{/if}}
 }

--- a/idlgen/hbs/variant.hbs
+++ b/idlgen/hbs/variant.hbs
@@ -3,7 +3,7 @@ type {{{lookup @root/type_names id}}} = enum {
   {{name}}
   {{~#if fields.[1]}}: struct { {{#each fields~}} {{#if @index}}, {{/if}}{{#if name}}{{name}}: {{/if}}{{{lookup @root/type_names type}}}{{/each}} }
   {{~else}}
-	  {{~#if fields.[0]}}: {{{lookup @root/type_names fields.[0].type}}}
+	  {{~#if fields.[0]}}: {{#with fields.[0]}} {{~#if name~}} struct { {{name}}: {{{lookup @root/type_names type}}} } {{~else~}} {{{lookup @root/type_names type}}} {{~/if}}{{/with}}
     {{~/if}}
   {{/if~}}
   ,

--- a/idlgen/src/errors.rs
+++ b/idlgen/src/errors.rs
@@ -24,6 +24,8 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 pub enum Error {
     #[error("funcion meta is invalid: {0}")]
     FuncMetaIsInvalid(String),
+    #[error("event meta is invalid: {0}")]
+    EventMetaIsInvalid(String),
     #[error("at least one service is required")]
     ServiceIsMissing,
     #[error("type id `{0}` is not found in the type registry")]

--- a/idlgen/src/snapshots/sails_idlgen__tests__generare_program_idl_works_with_empty_ctors.snap
+++ b/idlgen/src/snapshots/sails_idlgen__tests__generare_program_idl_works_with_empty_ctors.snap
@@ -50,5 +50,10 @@ service {
   DoThat : (par1: DoThatParam) -> result (struct { str, u32 }, struct { str });
   query This : (p1: u32, p2: str, p3: struct { opt str, u8 }, p4: TupleStruct, p5: GenericEnumForBoolAndU32) -> result (struct { str, u32 }, str);
   query That : (pr1: ThatParam) -> str;
+
+  events {
+    ThisDone: u32;
+    ThatDone: struct { p1: str };
+  }
 }
 

--- a/idlgen/src/snapshots/sails_idlgen__tests__generare_program_idl_works_with_non_empty_ctors.snap
+++ b/idlgen/src/snapshots/sails_idlgen__tests__generare_program_idl_works_with_non_empty_ctors.snap
@@ -55,5 +55,10 @@ service {
   DoThat : (par1: DoThatParam) -> result (struct { str, u32 }, struct { str });
   query This : (p1: u32, p2: str, p3: struct { opt str, u8 }, p4: TupleStruct, p5: GenericEnumForBoolAndU32) -> result (struct { str, u32 }, str);
   query That : (pr1: ThatParam) -> str;
+
+  events {
+    ThisDone: u32;
+    ThatDone: struct { p1: str };
+  }
 }
 

--- a/idlgen/src/snapshots/sails_idlgen__tests__generate_service_idl_works.snap
+++ b/idlgen/src/snapshots/sails_idlgen__tests__generate_service_idl_works.snap
@@ -50,5 +50,10 @@ service {
   DoThat : (par1: DoThatParam) -> result (struct { str, u32 }, struct { str });
   query This : (p1: u32, p2: str, p3: struct { opt str, u8 }, p4: TupleStruct, p5: GenericEnumForBoolAndU32) -> result (struct { str, u32 }, str);
   query That : (pr1: ThatParam) -> str;
+
+  events {
+    ThisDone: u32;
+    ThatDone: struct { p1: str };
+  }
 }
 

--- a/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works.snap
+++ b/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works.snap
@@ -52,6 +52,9 @@ impl sails_idl_meta::ServiceMeta for SomeService {
     fn queries() -> scale_info::MetaType {
         scale_info::MetaType::new::<meta::QueriesMeta>()
     }
+    fn events() -> scale_info::MetaType {
+        scale_info::MetaType::new::<meta::EventsMeta>()
+    }
 }
 #[derive(Decode, TypeInfo)]
 pub struct __DoThisParams {
@@ -72,5 +75,8 @@ mod meta {
     pub enum QueriesMeta {
         This(__ThisParams, bool),
     }
+    #[derive(TypeInfo)]
+    pub enum NoEvents {}
+    pub type EventsMeta = NoEvents;
 }
 

--- a/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works_for_lifetimes_and_generics.snap
+++ b/macros/core/src/snapshots/sails_macros_core__service__tests__gservice_works_for_lifetimes_and_generics.snap
@@ -2,9 +2,10 @@
 source: macros/core/src/service.rs
 expression: result
 ---
-impl<'a, 'b, T> SomeService<'a, 'b, T>
+impl<'a, 'b, T, TEventTrigger> SomeService<'a, 'b, T, TEventTrigger>
 where
     T: Clone,
+    TEventTrigger: EventTrigger<events::SomeEvents>,
 {
     pub fn do_this(&mut self) -> u32 {
         42
@@ -34,15 +35,20 @@ where
         return result.encode();
     }
 }
-impl<'a, 'b, T> sails_idl_meta::ServiceMeta for SomeService<'a, 'b, T>
+impl<'a, 'b, T, TEventTrigger> sails_idl_meta::ServiceMeta
+for SomeService<'a, 'b, T, TEventTrigger>
 where
     T: Clone,
+    TEventTrigger: EventTrigger<events::SomeEvents>,
 {
     fn commands() -> scale_info::MetaType {
         scale_info::MetaType::new::<meta::CommandsMeta>()
     }
     fn queries() -> scale_info::MetaType {
         scale_info::MetaType::new::<meta::QueriesMeta>()
+    }
+    fn events() -> scale_info::MetaType {
+        scale_info::MetaType::new::<meta::EventsMeta>()
     }
 }
 #[derive(Decode, TypeInfo)]
@@ -55,5 +61,8 @@ mod meta {
     }
     #[derive(TypeInfo)]
     pub enum QueriesMeta {}
+    #[derive(TypeInfo)]
+    pub enum NoEvents {}
+    pub type EventsMeta = events::SomeEvents;
 }
 


### PR DESCRIPTION
This PR introduces generation of the `events` section for IDL.
The event type is discovered through the `EventTrigger<EventType>` trait bound used by service.