### PR TITLE
feat(idl-parser): Introduce support for multiple services

### DIFF
--- a/idlgen/tests/generator.rs
+++ b/idlgen/tests/generator.rs
@@ -172,7 +172,8 @@ fn generare_program_idl_works_with_empty_ctors() {
     insta::assert_snapshot!(generated_idl);
     let generated_idl_program = generated_idl_program.unwrap();
     assert!(generated_idl_program.ctor().is_none());
-    assert_eq!(generated_idl_program.service().funcs().len(), 4);
+    assert_eq!(generated_idl_program.services().len(), 1);
+    assert_eq!(generated_idl_program.services()[0].funcs().len(), 4);
     assert_eq!(generated_idl_program.types().len(), 8);
 }
 
@@ -186,7 +187,8 @@ fn generare_program_idl_works_with_non_empty_ctors() {
     insta::assert_snapshot!(generated_idl);
     let generated_idl_program = generated_idl_program.unwrap();
     assert_eq!(generated_idl_program.ctor().unwrap().funcs().len(), 2);
-    assert_eq!(generated_idl_program.service().funcs().len(), 4);
+    assert_eq!(generated_idl_program.services().len(), 1);
+    assert_eq!(generated_idl_program.services()[0].funcs().len(), 4);
     assert_eq!(generated_idl_program.types().len(), 8);
 }
 
@@ -200,6 +202,7 @@ fn generate_service_idl_works() {
     insta::assert_snapshot!(generated_idl);
     let generated_idl_program = generated_idl_program.unwrap();
     assert!(generated_idl_program.ctor().is_none());
-    assert_eq!(generated_idl_program.service().funcs().len(), 4);
+    assert_eq!(generated_idl_program.services().len(), 1);
+    assert_eq!(generated_idl_program.services()[0].funcs().len(), 4);
     assert_eq!(generated_idl_program.types().len(), 8);
 }

--- a/idlparser/src/ffi/ast/mod.rs
+++ b/idlparser/src/ffi/ast/mod.rs
@@ -45,6 +45,8 @@ pub struct CtorFunc {
 #[repr(C)]
 pub struct Service {
     raw_ptr: Ptr,
+    name_ptr: *const u8,
+    name_len: u32,
 }
 
 #[repr(C)]

--- a/idlparser/src/ffi/ast/visitor.rs
+++ b/idlparser/src/ffi/ast/visitor.rs
@@ -410,8 +410,11 @@ mod wrapper {
             if fn_ptr_addr!(self.visitor.visit_service).is_null() {
                 return raw_visitor::accept_service(service, self);
             }
+            let name_bytes = service.name().as_bytes();
             let service = Service {
                 raw_ptr: service.into(),
+                name_ptr: name_bytes.as_ptr(),
+                name_len: name_bytes.len() as u32,
             };
             unsafe { (self.visitor.visit_service)(self.context, &service) };
         }

--- a/idlparser/src/grammar.lalrpop
+++ b/idlparser/src/grammar.lalrpop
@@ -36,10 +36,10 @@ extern {
 }
 
 pub Program: Program = {
-    <types: (<Separated<Type, ";">> ";")?> <ctor: (Ctor ";")?> <service: Service> ";"? =>
+    <types: (<Separated<Type, ";">> ";")?> <ctor: (Ctor ";")?> <services: Separated<Service, ";">> =>
         Program::new(
             ctor.map(|c| c.0),
-            service,
+            services,
             types.unwrap_or_default(),
         ),
 }
@@ -54,8 +54,8 @@ CtorFunc : CtorFunc = {
 }
 
 Service: Service = {
-    "service" "{" <funcs: Separated<ServiceFunc, ";">> <events: ("events" "{" <Separated<EnumVariant, ";">> "}")?> "}" =>
-        Service::new(funcs, events.unwrap_or_default()),
+    "service" <name: "id"?> "{" <funcs: Separated<ServiceFunc, ";">> <events: ("events" "{" <Separated<EnumVariant, ";">> "}")?> "}" =>
+        Service::new(name.unwrap_or_default(), funcs, events.unwrap_or_default()),
 }
 
 ServiceFunc: ServiceFunc = {


### PR DESCRIPTION
Some steps towards resolving #87 
This PR introduces support for multiple services in `idl-parser`. Some checks like unique service names are still missing though and will be implemented in a separate PR.