### PR TITLE
fix(events): Prefix emitted events with service invocation route

### DIFF
--- a/examples/rmrk/resource/wasm/tests/resources.rs
+++ b/examples/rmrk/resource/wasm/tests/resources.rs
@@ -64,6 +64,7 @@ fn adding_resource_to_storage_by_admin_succeeds() {
     assert!(run_result.contains(&(ADMIN_ID, expected_response)));
 
     let expected_event = [
+        resources::RESOURCE_SERVICE_NAME.encode().as_slice(),
         "ResourceAdded".encode().as_slice(),
         &ResourceStorageEvent::ResourceAdded {
             resource_id: RESOURCE_ID,

--- a/js/README.md
+++ b/js/README.md
@@ -83,20 +83,20 @@ The key of the object is the name of the event and the value is an object with t
 ```
 
 ### Get function name and decode bytes
-Use `sails.getServiceName` method to get the service name from the payload bytes.
-Use `sails.getFnName` method to get the function name from the payload bytes.
+Use `getServiceNamePrefix` function to get the service name from the payload bytes.
+Use `getFnNamePrefix` method to get the function or event name from the payload bytes.
 Use `sails.services.ServiceName.functions.FuncitonName.decodePayload` method of the function object to decode the payload bytes of the send message.
 Use `sails.services.ServiceName.functions.FuncitonName.decodeResult` method of the function object to decode the result bytes of the received message.
 
 ```javascript
+import { getServiceNamePrefix, getFnNamePrefix } from 'sails-js';
 const payloadOfSentMessage = '0x<some bytes>';
-const serviceName = sails.getServiceName(payloadOfSentMessage);
-const functionName = sails.getFnName(payloadOfSentMessage);
+const serviceName = getServiceNamePrefix(payloadOfSentMessage);
+const functionName = getFnNamePrefix(payloadOfSentMessage);
 console.log(sails.services[serviceName].functions[functionName].decodeResult(payloadOfSentMessage));
 
 const payloadOfReceivedMessage = '0x<some bytes>';
-const functionName = sails.getFunctionName(payloadOfReceivedMessage);
-console.log(sails.functions[functionName].decodePayload(payloadOfReceivedMessage));
+console.log(sails.service[serviceName].functions[functionName].decodePayload(payloadOfReceivedMessage));
 ```
 
 The same approach can be used to encode/decode bytes of the contructor or event.

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Parser and typescript code generator from Sails IDL files",
   "main": "lib/index.js",
   "preferGlobal": true,

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,2 +1,3 @@
 export { Sails } from './sails.js';
 export { TransactionBuilder } from './transaction-builder.js';
+export { getServiceNamePrefix, getFnNamePrefix } from './utils/index.js';

--- a/js/src/utils/index.ts
+++ b/js/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './payload-method.js';
 export * from './types.js';
 export * from './types-replace.js';
 export * from './string.js';
+export * from './prefix.js'

--- a/js/src/utils/prefix.ts
+++ b/js/src/utils/prefix.ts
@@ -1,0 +1,30 @@
+import { u8aToString, hexToU8a, compactFromU8aLim } from '@polkadot/util';
+import { HexString } from '@gear-js/api';
+
+/**
+ * ## Get service name prefix
+ * @param payload in hex string format
+ * @returns Name of the service
+ */
+export const getServiceNamePrefix = (payload: HexString): string => {
+  const _payload = hexToU8a(payload);
+  const [offset, limit] = compactFromU8aLim(_payload);
+
+  return u8aToString(_payload.subarray(offset, limit + offset));
+};
+
+/**
+ * ## Get function (or event) name prefix
+ * @param payload in hex string format
+ * @returns Name of the function
+ */
+export function getFnNamePrefix(payload: HexString) {
+  const _payload = hexToU8a(payload);
+
+  const [sOff, sLim] = compactFromU8aLim(_payload);
+  const serviceOffset = sOff + sLim;
+
+  const [offset, limit] = compactFromU8aLim(_payload.subarray(serviceOffset));
+
+  return u8aToString(_payload.subarray(serviceOffset + offset, serviceOffset + offset + limit));
+}

--- a/js/test/rmrk-catalog.test.ts
+++ b/js/test/rmrk-catalog.test.ts
@@ -97,7 +97,7 @@ describe('RMRK catalog', () => {
 
     expect(replyMsg).toBeDefined();
 
-    const result = sails.services.RmrkCatalog.functions.AddParts.decodeResult(replyMsg.data.message.payload);
+    const result = sails.services.RmrkCatalog.functions.AddParts.decodeResult(replyMsg.data.message.payload.toHex());
 
     expect(result).toEqual({
       ok: {

--- a/js/test/rmrk-resource.test.ts
+++ b/js/test/rmrk-resource.test.ts
@@ -95,7 +95,7 @@ describe('RMRK resource', () => {
         return;
       }
 
-      resourceAddedEvent = sails.services.RmrkResource.events.ResourceAdded.decode(event.data.message.payload.toU8a());
+      resourceAddedEvent = sails.services.RmrkResource.events.ResourceAdded.decode(event.data.message.payload.toHex());
     });
 
     let [msgId, blockHash] = await new Promise<[HexString, HexString]>((resolve, reject) => {
@@ -118,7 +118,9 @@ describe('RMRK resource', () => {
 
     expect(replyMsg).toBeDefined();
 
-    const result = sails.services.RmrkResource.functions.AddResourceEntry.decodeResult(replyMsg.data.message.payload);
+    const result = sails.services.RmrkResource.functions.AddResourceEntry.decodeResult(
+      replyMsg.data.message.payload.toHex(),
+    );
 
     expect(result).toEqual({
       ok: [

--- a/macros/core/src/program.rs
+++ b/macros/core/src/program.rs
@@ -109,9 +109,9 @@ fn generate_init(
 
             quote!(
                 if #input_ident.starts_with(& [ #(#invocation_route_bytes),* ]) {
+                    static INVOCATION_ROUTE: [u8; #invocation_route_len] = [ #(#invocation_route_bytes),* ];
                     let request = #invocation_params_struct_ident::decode(&mut &#input_ident[#invocation_route_len..]).expect("Failed to decode request");
                     let program = #program_type_path :: #handler_ident (#(#handler_args),*) #handler_await;
-                    static INVOCATION_ROUTE: [u8; #invocation_route_len] = [ #(#invocation_route_bytes),* ];
                     (program, INVOCATION_ROUTE.as_ref())
                 }
             )
@@ -208,10 +208,11 @@ fn generate_handle(
 
                 quote!(
                     if #input_ident.starts_with(& [ #(#invocation_route_bytes),* ]) {
+                        static INVOCATION_ROUTE: [u8; #invocation_route_len] = [ #(#invocation_route_bytes),* ];
+                        let msg_scope = gstd::__create_message_scope(INVOCATION_ROUTE.as_ref());
                         let program_ref = unsafe { #program_ident.as_ref() }.expect("Program not initialized");
                         let mut service = program_ref.#service_ctor_ident();
                         let output = service.handle(&#input_ident[#invocation_route_len..]).await;
-                        static INVOCATION_ROUTE: [u8; #invocation_route_len] = [ #(#invocation_route_bytes),* ];
                         [INVOCATION_ROUTE.as_ref(), &output].concat()
                     }
                 )

--- a/macros/core/tests/snapshots/program__gprogram_generates_handle_for_multiple_services_with_empty_and_non_empty_routes.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_handle_for_multiple_services_with_empty_and_non_empty_routes.snap
@@ -67,10 +67,6 @@ pub mod wasm {
         let output = if input
             .starts_with(&[32u8, 83u8, 101u8, 114u8, 118u8, 105u8, 99u8, 101u8, 50u8])
         {
-            let program_ref = unsafe { PROGRAM.as_ref() }
-                .expect("Program not initialized");
-            let mut service = program_ref.service2();
-            let output = service.handle(&input[9usize..]).await;
             static INVOCATION_ROUTE: [u8; 9usize] = [
                 32u8,
                 83u8,
@@ -82,6 +78,11 @@ pub mod wasm {
                 101u8,
                 50u8,
             ];
+            let msg_scope = gstd::__create_message_scope(INVOCATION_ROUTE.as_ref());
+            let program_ref = unsafe { PROGRAM.as_ref() }
+                .expect("Program not initialized");
+            let mut service = program_ref.service2();
+            let output = service.handle(&input[9usize..]).await;
             [INVOCATION_ROUTE.as_ref(), &output].concat()
         } else {
             let program_ref = unsafe { PROGRAM.as_ref() }

--- a/macros/core/tests/snapshots/program__gprogram_generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -67,10 +67,6 @@ pub mod wasm {
         let output = if input
             .starts_with(&[32u8, 83u8, 101u8, 114u8, 118u8, 105u8, 99u8, 101u8, 50u8])
         {
-            let program_ref = unsafe { PROGRAM.as_ref() }
-                .expect("Program not initialized");
-            let mut service = program_ref.service2();
-            let output = service.handle(&input[9usize..]).await;
             static INVOCATION_ROUTE: [u8; 9usize] = [
                 32u8,
                 83u8,
@@ -82,13 +78,19 @@ pub mod wasm {
                 101u8,
                 50u8,
             ];
+            let msg_scope = gstd::__create_message_scope(INVOCATION_ROUTE.as_ref());
+            let program_ref = unsafe { PROGRAM.as_ref() }
+                .expect("Program not initialized");
+            let mut service = program_ref.service2();
+            let output = service.handle(&input[9usize..]).await;
             [INVOCATION_ROUTE.as_ref(), &output].concat()
         } else if input.starts_with(&[16u8, 83u8, 118u8, 99u8, 49u8]) {
+            static INVOCATION_ROUTE: [u8; 5usize] = [16u8, 83u8, 118u8, 99u8, 49u8];
+            let msg_scope = gstd::__create_message_scope(INVOCATION_ROUTE.as_ref());
             let program_ref = unsafe { PROGRAM.as_ref() }
                 .expect("Program not initialized");
             let mut service = program_ref.service1();
             let output = service.handle(&input[5usize..]).await;
-            static INVOCATION_ROUTE: [u8; 5usize] = [16u8, 83u8, 118u8, 99u8, 49u8];
             [INVOCATION_ROUTE.as_ref(), &output].concat()
         } else {
             let input = String::decode(&mut input)

--- a/macros/core/tests/snapshots/program__gprogram_generates_handle_for_single_service_with_non_empty_route.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_handle_for_single_service_with_non_empty_route.snap
@@ -59,10 +59,6 @@ pub mod wasm {
         let output = if input
             .starts_with(&[28u8, 83u8, 101u8, 114u8, 118u8, 105u8, 99u8, 101u8])
         {
-            let program_ref = unsafe { PROGRAM.as_ref() }
-                .expect("Program not initialized");
-            let mut service = program_ref.service();
-            let output = service.handle(&input[8usize..]).await;
             static INVOCATION_ROUTE: [u8; 8usize] = [
                 28u8,
                 83u8,
@@ -73,6 +69,11 @@ pub mod wasm {
                 99u8,
                 101u8,
             ];
+            let msg_scope = gstd::__create_message_scope(INVOCATION_ROUTE.as_ref());
+            let program_ref = unsafe { PROGRAM.as_ref() }
+                .expect("Program not initialized");
+            let mut service = program_ref.service();
+            let output = service.handle(&input[8usize..]).await;
             [INVOCATION_ROUTE.as_ref(), &output].concat()
         } else {
             let input = String::decode(&mut input)

--- a/macros/core/tests/snapshots/program__gprogram_generates_init_for_multiple_ctors.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_init_for_multiple_ctors.snap
@@ -51,16 +51,16 @@ pub mod wasm {
         let (program, invocation_route) = if input
             .starts_with(&[12u8, 78u8, 101u8, 119u8])
         {
+            static INVOCATION_ROUTE: [u8; 4usize] = [12u8, 78u8, 101u8, 119u8];
             let request = __NewParams::decode(&mut &input[4usize..])
                 .expect("Failed to decode request");
             let program = MyProgram::new(request.p1, request.p2).await;
-            static INVOCATION_ROUTE: [u8; 4usize] = [12u8, 78u8, 101u8, 119u8];
             (program, INVOCATION_ROUTE.as_ref())
         } else if input.starts_with(&[16u8, 78u8, 101u8, 119u8, 50u8]) {
+            static INVOCATION_ROUTE: [u8; 5usize] = [16u8, 78u8, 101u8, 119u8, 50u8];
             let request = __New2Params::decode(&mut &input[5usize..])
                 .expect("Failed to decode request");
             let program = MyProgram::new2(request.p2, request.p1);
-            static INVOCATION_ROUTE: [u8; 5usize] = [16u8, 78u8, 101u8, 119u8, 50u8];
             (program, INVOCATION_ROUTE.as_ref())
         } else {
             let input = String::decode(&mut input)

--- a/macros/core/tests/snapshots/program__gprogram_generates_init_for_single_ctor.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_init_for_single_ctor.snap
@@ -42,10 +42,10 @@ pub mod wasm {
         let (program, invocation_route) = if input
             .starts_with(&[12u8, 78u8, 101u8, 119u8])
         {
+            static INVOCATION_ROUTE: [u8; 4usize] = [12u8, 78u8, 101u8, 119u8];
             let request = __NewParams::decode(&mut &input[4usize..])
                 .expect("Failed to decode request");
             let program = MyProgram::new(request.p1, request.p2).await;
-            static INVOCATION_ROUTE: [u8; 4usize] = [12u8, 78u8, 101u8, 119u8];
             (program, INVOCATION_ROUTE.as_ref())
         } else {
             let input = String::decode(&mut input)

--- a/rtl/src/gstd/mod.rs
+++ b/rtl/src/gstd/mod.rs
@@ -1,10 +1,40 @@
-use crate::{ActorId, ExecContext, MessageId};
+use crate::{collections::BTreeMap, ActorId, ExecContext, MessageId};
 use core::cell::OnceCell;
 pub use gstd::{async_init, async_main, handle_signal, message_loop, msg, record_reply};
 
 pub mod calls;
 pub mod events;
 mod types;
+
+static mut MESSAGE_ID_TO_SERVICE_ROUTE: BTreeMap<MessageId, &'static [u8]> = BTreeMap::new();
+
+pub fn __create_message_scope(service_route: &'static [u8]) -> __MessageScope {
+    let msg_id = current_message_id();
+    unsafe { MESSAGE_ID_TO_SERVICE_ROUTE.insert(msg_id, service_route) };
+    __MessageScope { msg_id }
+}
+
+pub struct __MessageScope {
+    msg_id: MessageId,
+}
+
+impl Drop for __MessageScope {
+    fn drop(&mut self) {
+        let removed_value = unsafe { MESSAGE_ID_TO_SERVICE_ROUTE.remove(&self.msg_id) };
+        if removed_value.is_none() {
+            panic!("Service route not found for message id: {:?}", self.msg_id);
+        }
+    }
+}
+
+fn message_service_route(msg_id: MessageId) -> &'static [u8] {
+    let service_route = unsafe { MESSAGE_ID_TO_SERVICE_ROUTE.get(&msg_id).copied() };
+    service_route.unwrap_or_else(|| panic!("Service route not found for message id: {:?}", msg_id))
+}
+
+fn current_message_id() -> MessageId {
+    msg::id().into()
+}
 
 #[derive(Default)]
 pub struct GStdExecContext {

--- a/rtl/src/gstd/mod.rs
+++ b/rtl/src/gstd/mod.rs
@@ -10,7 +10,13 @@ static mut MESSAGE_ID_TO_SERVICE_ROUTE: BTreeMap<MessageId, &'static [u8]> = BTr
 
 pub fn __create_message_scope(service_route: &'static [u8]) -> __MessageScope {
     let msg_id = current_message_id();
-    unsafe { MESSAGE_ID_TO_SERVICE_ROUTE.insert(msg_id, service_route) };
+    let prev_value = unsafe { MESSAGE_ID_TO_SERVICE_ROUTE.insert(msg_id, service_route) };
+    if prev_value.is_some() {
+        panic!(
+            "Service route already registered for message id: {:?}",
+            msg_id
+        );
+    }
     __MessageScope { msg_id }
 }
 


### PR DESCRIPTION
Each emitted event payload needs be prefixed with service name/invocation route. Event trigger resolves the latter via a map which is maintained by dispatching code which attributes id of being processed message with the route. The approach requires at least 2 calls to `gstd::msg::id()` which is not that cheap. Current there is no option to cache it somehow.