### PR TITLE
feat(macros): Test gprogram without exposed services

### DIFF
--- a/macros/tests/integration_tests.rs
+++ b/macros/tests/integration_tests.rs
@@ -31,6 +31,12 @@ fn gservice_works_for_lifecycles_and_generics() {
 }
 
 #[test]
+fn gprogram_works_with_no_exposed_services() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/gprogram_works_with_no_exposed_services.rs");
+}
+
+#[test]
 fn gprogram_fails_for_multiple_services_with_same_route() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/gprogram_fails_for_multiple_services_with_same_route.rs");

--- a/macros/tests/ui/gprogram_works_with_no_exposed_services.rs
+++ b/macros/tests/ui/gprogram_works_with_no_exposed_services.rs
@@ -1,0 +1,16 @@
+use sails_macros::gprogram;
+use sails_rtl;
+
+struct MyProgram;
+
+#[gprogram]
+impl MyProgram {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let _ = MyProgram::new();
+}


### PR DESCRIPTION
Apparently #202 was addressed in https://github.com/gear-tech/sails/pull/214, so I'm just adding a test for it.

resolves #202
