### PR TITLE
feat(macros): Use exposed service in code generated by 'gprogram' macro

### DIFF
--- a/examples/puppeteer/wasm/src/lib.rs
+++ b/examples/puppeteer/wasm/src/lib.rs
@@ -27,7 +27,7 @@ async fn main() {
     let input_bytes = msg::load_bytes().expect("Failed to read input");
     let output_bytes = service()
         .clone()
-        .expose(&[1, 2, 3])
+        .expose(msg::id().into(), &[1, 2, 3])
         .handle(&input_bytes)
         .await;
     msg::reply_bytes(output_bytes, 0).expect("Failed to send output");

--- a/examples/this-that-svc/wasm/src/lib.rs
+++ b/examples/this-that-svc/wasm/src/lib.rs
@@ -1,14 +1,13 @@
 #![no_std]
 
-use gstd::msg;
-use sails_rtl::gstd::services::Service;
+use sails_rtl::gstd::{msg, services::Service};
 use this_that_svc_app::MyService;
 
 #[gstd::async_main]
 async fn main() {
     let input_bytes = msg::load_bytes().expect("Failed to read input");
     let output_bytes = MyService::new()
-        .expose(&[1, 2, 3])
+        .expose(msg::id().into(), &[1, 2, 3])
         .handle(&input_bytes)
         .await;
     msg::reply_bytes(output_bytes, 0).expect("Failed to send output");

--- a/macros/core/src/program.rs
+++ b/macros/core/src/program.rs
@@ -148,7 +148,11 @@ fn wire_up_service_exposure(
     );
     wrapping_service_ctor_fn.block = parse_quote!({
         let service = self. #original_service_ctor_fn_ident ();
-        let exposure = < #service_type as sails_rtl::gstd::services::Service>::expose(service, #route_ident .as_ref());
+        let exposure = < #service_type as sails_rtl::gstd::services::Service>::expose(
+            service,
+            sails_rtl::gstd::msg::id().into(),
+            #route_ident .as_ref(),
+        );
         exposure
     });
     program_impl.items[ctor_idx] = ImplItem::Fn(wrapping_service_ctor_fn);
@@ -266,7 +270,6 @@ fn generate_handle<'a>(
         invocation_dispatches.push({
             quote!(
                 if #input_ident.starts_with(& #service_route_ident) {
-                    let msg_scope = gstd::__create_message_scope(#service_route_ident .as_ref());
                     let program_ref = unsafe { #program_ident.as_ref() }.expect("Program not initialized");
                     let mut service = program_ref.#service_ctor_ident();
                     let output = service.handle(&#input_ident[#service_route_ident .len()..]).await;

--- a/macros/core/tests/snapshots/program__gprogram_generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -22,6 +22,7 @@ impl MyProgram {
         let service = self.__service1();
         let exposure = <MyService as sails_rtl::gstd::services::Service>::expose(
             service,
+            sails_rtl::gstd::msg::id().into(),
             __ROUTE_SVC1.as_ref(),
         );
         exposure
@@ -32,6 +33,7 @@ impl MyProgram {
         let service = self.__service2();
         let exposure = <MyService as sails_rtl::gstd::services::Service>::expose(
             service,
+            sails_rtl::gstd::msg::id().into(),
             __ROUTE_SERVICE2.as_ref(),
         );
         exposure
@@ -97,14 +99,12 @@ pub mod wasm {
     async fn main() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
         let output = if input.starts_with(&__ROUTE_SERVICE2) {
-            let msg_scope = gstd::__create_message_scope(__ROUTE_SERVICE2.as_ref());
             let program_ref = unsafe { PROGRAM.as_ref() }
                 .expect("Program not initialized");
             let mut service = program_ref.service2();
             let output = service.handle(&input[__ROUTE_SERVICE2.len()..]).await;
             [__ROUTE_SERVICE2.as_ref(), &output].concat()
         } else if input.starts_with(&__ROUTE_SVC1) {
-            let msg_scope = gstd::__create_message_scope(__ROUTE_SVC1.as_ref());
             let program_ref = unsafe { PROGRAM.as_ref() }
                 .expect("Program not initialized");
             let mut service = program_ref.service1();
@@ -127,4 +127,3 @@ pub mod wasm {
         gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
     }
 }
-

--- a/macros/core/tests/snapshots/program__gprogram_generates_handle_for_single_service_with_non_empty_route.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_handle_for_single_service_with_non_empty_route.snap
@@ -19,6 +19,7 @@ impl MyProgram {
         let service = self.__service();
         let exposure = <MyService as sails_rtl::gstd::services::Service>::expose(
             service,
+            sails_rtl::gstd::msg::id().into(),
             __ROUTE_SERVICE.as_ref(),
         );
         exposure
@@ -77,7 +78,6 @@ pub mod wasm {
     async fn main() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
         let output = if input.starts_with(&__ROUTE_SERVICE) {
-            let msg_scope = gstd::__create_message_scope(__ROUTE_SERVICE.as_ref());
             let program_ref = unsafe { PROGRAM.as_ref() }
                 .expect("Program not initialized");
             let mut service = program_ref.service();
@@ -100,4 +100,3 @@ pub mod wasm {
         gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
     }
 }
-

--- a/macros/core/tests/snapshots/service__gservice_works.snap
+++ b/macros/core/tests/snapshots/service__gservice_works.snap
@@ -11,14 +11,17 @@ impl SomeService {
     }
 }
 pub struct Exposure<T> {
+    message_id: sails_rtl::MessageId,
     route: &'static [u8],
     inner: T,
 }
 impl Exposure<SomeService> {
     pub async fn do_this(&mut self, p1: u32, p2: String) -> u32 {
+        let exposure_scope = sails_rtl::gstd::services::ExposureCallScope::new(self);
         self.inner.do_this(p1, p2).await
     }
     pub fn this(&self, p1: bool) -> bool {
+        let exposure_scope = sails_rtl::gstd::services::ExposureCallScope::new(self);
         self.inner.this(p1)
     }
     pub async fn handle(&mut self, mut input: &[u8]) -> Vec<u8> {
@@ -57,10 +60,23 @@ impl Exposure<SomeService> {
         return result.encode();
     }
 }
+impl sails_rtl::gstd::services::Exposure for Exposure<SomeService> {
+    fn message_id(&self) -> sails_rtl::MessageId {
+        self.message_id
+    }
+    fn route(&self) -> &'static [u8] {
+        self.route
+    }
+}
 impl sails_rtl::gstd::services::Service for SomeService {
     type Exposure = Exposure<SomeService>;
-    fn expose(self, route: &'static [u8]) -> Self::Exposure {
+    fn expose(
+        self,
+        message_id: sails_rtl::MessageId,
+        route: &'static [u8],
+    ) -> Self::Exposure {
         Self::Exposure {
+            message_id,
             route,
             inner: self,
         }
@@ -100,4 +116,3 @@ mod meta {
     pub enum NoEvents {}
     pub type EventsMeta = NoEvents;
 }
-

--- a/macros/core/tests/snapshots/service__gservice_works_for_lifetimes_and_generics.snap
+++ b/macros/core/tests/snapshots/service__gservice_works_for_lifetimes_and_generics.snap
@@ -12,6 +12,7 @@ where
     }
 }
 pub struct Exposure<T> {
+    message_id: sails_rtl::MessageId,
     route: &'static [u8],
     inner: T,
 }
@@ -21,6 +22,7 @@ where
     TEventTrigger: EventTrigger<events::SomeEvents>,
 {
     pub fn do_this(&mut self) -> u32 {
+        let exposure_scope = sails_rtl::gstd::services::ExposureCallScope::new(self);
         self.inner.do_this()
     }
     pub async fn handle(&mut self, mut input: &[u8]) -> Vec<u8> {
@@ -48,6 +50,19 @@ where
         return result.encode();
     }
 }
+impl<'a, 'b, T, TEventTrigger> sails_rtl::gstd::services::Exposure
+for Exposure<SomeService<'a, 'b, T, TEventTrigger>>
+where
+    T: Clone,
+    TEventTrigger: EventTrigger<events::SomeEvents>,
+{
+    fn message_id(&self) -> sails_rtl::MessageId {
+        self.message_id
+    }
+    fn route(&self) -> &'static [u8] {
+        self.route
+    }
+}
 impl<'a, 'b, T, TEventTrigger> sails_rtl::gstd::services::Service
 for SomeService<'a, 'b, T, TEventTrigger>
 where
@@ -55,8 +70,13 @@ where
     TEventTrigger: EventTrigger<events::SomeEvents>,
 {
     type Exposure = Exposure<SomeService<'a, 'b, T, TEventTrigger>>;
-    fn expose(self, route: &'static [u8]) -> Self::Exposure {
+    fn expose(
+        self,
+        message_id: sails_rtl::MessageId,
+        route: &'static [u8],
+    ) -> Self::Exposure {
         Self::Exposure {
+            message_id,
             route,
             inner: self,
         }
@@ -92,4 +112,3 @@ mod meta {
     pub enum NoEvents {}
     pub type EventsMeta = events::SomeEvents;
 }
-

--- a/macros/tests/ui/gservice_works.rs
+++ b/macros/tests/ui/gservice_works.rs
@@ -1,6 +1,6 @@
 use parity_scale_codec::{Decode, Encode};
 use sails_macros::gservice;
-use sails_rtl::gstd::services::Service;
+use sails_rtl::{gstd::services::Service, MessageId};
 use scale_info::TypeInfo;
 
 struct MyService;
@@ -35,7 +35,10 @@ async fn main() {
         .encode(),
     ]
     .concat();
-    let output = MyService.expose(&[1, 2, 3]).handle(&input).await;
+    let output = MyService
+        .expose(MessageId::from(123), &[1, 2, 3])
+        .handle(&input)
+        .await;
     let mut output = output.as_slice();
 
     let func_name = String::decode(&mut output).unwrap();

--- a/macros/tests/ui/gservice_works_for_lifecycles_and_generics.rs
+++ b/macros/tests/ui/gservice_works_for_lifecycles_and_generics.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use parity_scale_codec::{Decode, Encode};
 use sails_macros::gservice;
-use sails_rtl::gstd::services::Service;
+use sails_rtl::{gstd::services::Service, MessageId};
 use scale_info::TypeInfo;
 
 struct MyService<'a, T> {
@@ -25,7 +25,7 @@ async fn main() {
     let my_service = MyService::<'_, String> { _a: PhantomData };
 
     let output = my_service
-        .expose(&[1, 2, 3])
+        .expose(MessageId::from(123), &[1, 2, 3])
         .handle(&DO_THIS.encode())
         .await;
     let mut output = output.as_slice();

--- a/rtl/src/gstd/events.rs
+++ b/rtl/src/gstd/events.rs
@@ -1,6 +1,11 @@
-use crate::{collections::HashMap, errors::*, Vec};
+use crate::{
+    collections::HashMap,
+    errors::*,
+    gstd::{msg, services},
+    Vec,
+};
 use core::{any::TypeId, marker::PhantomData};
-use gstd::{msg, ActorId as GStdActorId};
+use gstd::ActorId as GStdActorId;
 use parity_scale_codec::Encode;
 use scale_info::{StaticTypeInfo, TypeDef};
 
@@ -78,10 +83,8 @@ where
     TEvents: Encode + StaticTypeInfo,
 {
     fn trigger(&self, event: TEvents) -> Result<()> {
-        let payload = Self::compose_payload(
-            super::message_service_route(super::current_message_id()),
-            event,
-        )?;
+        let payload =
+            Self::compose_payload(services::exposure_context(msg::id().into()).route(), event)?;
         msg::send_bytes(GStdActorId::zero(), payload, 0)?;
         Ok(())
     }

--- a/rtl/src/gstd/mod.rs
+++ b/rtl/src/gstd/mod.rs
@@ -1,4 +1,4 @@
-use crate::{collections::BTreeMap, ActorId, MessageId};
+use crate::{ActorId, MessageId};
 use core::cell::OnceCell;
 pub use gstd::{async_init, async_main, handle_signal, message_loop, msg, record_reply};
 
@@ -6,42 +6,6 @@ pub mod calls;
 pub mod events;
 pub mod services;
 mod types;
-
-static mut MESSAGE_ID_TO_SERVICE_ROUTE: BTreeMap<MessageId, &'static [u8]> = BTreeMap::new();
-
-pub fn __create_message_scope(service_route: &'static [u8]) -> __MessageScope {
-    let msg_id = current_message_id();
-    let prev_value = unsafe { MESSAGE_ID_TO_SERVICE_ROUTE.insert(msg_id, service_route) };
-    if prev_value.is_some() {
-        panic!(
-            "Service route already registered for message id: {:?}",
-            msg_id
-        );
-    }
-    __MessageScope { msg_id }
-}
-
-pub struct __MessageScope {
-    msg_id: MessageId,
-}
-
-impl Drop for __MessageScope {
-    fn drop(&mut self) {
-        let removed_value = unsafe { MESSAGE_ID_TO_SERVICE_ROUTE.remove(&self.msg_id) };
-        if removed_value.is_none() {
-            panic!("Service route not found for message id: {:?}", self.msg_id);
-        }
-    }
-}
-
-fn message_service_route(msg_id: MessageId) -> &'static [u8] {
-    let service_route = unsafe { MESSAGE_ID_TO_SERVICE_ROUTE.get(&msg_id).copied() };
-    service_route.unwrap_or_else(|| panic!("Service route not found for message id: {:?}", msg_id))
-}
-
-fn current_message_id() -> MessageId {
-    msg::id().into()
-}
 
 // TODO: To be renamed into SysCalls or something similar
 pub trait ExecContext {

--- a/rtl/src/gstd/services.rs
+++ b/rtl/src/gstd/services.rs
@@ -1,5 +1,84 @@
-pub trait Service {
-    type Exposure;
+use crate::{collections::BTreeMap, MessageId, Vec};
 
-    fn expose(self, route: &'static [u8]) -> Self::Exposure;
+static mut MESSAGE_ID_TO_SERVICE_ROUTE: BTreeMap<MessageId, Vec<&'static [u8]>> = BTreeMap::new();
+
+pub trait Service {
+    type Exposure: Exposure;
+
+    fn expose(self, message_id: MessageId, route: &'static [u8]) -> Self::Exposure;
+}
+
+pub trait Exposure {
+    fn message_id(&self) -> MessageId;
+    fn route(&self) -> &'static [u8];
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ExposureContext {
+    message_id: MessageId,
+    route: &'static [u8],
+}
+
+impl ExposureContext {
+    pub fn message_id(&self) -> MessageId {
+        self.message_id
+    }
+
+    pub fn route(&self) -> &'static [u8] {
+        self.route
+    }
+}
+
+pub(crate) fn exposure_context(message_id: MessageId) -> ExposureContext {
+    let route = unsafe {
+        MESSAGE_ID_TO_SERVICE_ROUTE
+            .get(&message_id)
+            .and_then(|routes| routes.last().copied())
+            .unwrap_or_else(|| {
+                panic!(
+                    "Exposure context is not found for message id {:?}",
+                    message_id
+                )
+            })
+    };
+    ExposureContext { message_id, route }
+}
+
+pub struct ExposureCallScope {
+    message_id: MessageId,
+    route: &'static [u8],
+}
+
+impl ExposureCallScope {
+    pub fn new(exposure: &impl Exposure) -> Self {
+        let routes = unsafe {
+            MESSAGE_ID_TO_SERVICE_ROUTE
+                .entry(exposure.message_id())
+                .or_default()
+        };
+        routes.push(exposure.route());
+        Self {
+            message_id: exposure.message_id(),
+            route: exposure.route(),
+        }
+    }
+}
+
+impl Drop for ExposureCallScope {
+    fn drop(&mut self) {
+        let routes = unsafe {
+            MESSAGE_ID_TO_SERVICE_ROUTE
+                .get_mut(&self.message_id)
+                .unwrap_or_else(|| unreachable!("Entry for message should always exist"))
+        };
+        let route = routes
+            .pop()
+            .unwrap_or_else(|| unreachable!("Route should always exist"));
+        if route != self.route {
+            unreachable!("Route should always match");
+        }
+        if routes.is_empty() {
+            unsafe { MESSAGE_ID_TO_SERVICE_ROUTE.remove(&self.message_id) };
+        }
+    }
 }


### PR DESCRIPTION
Resolves #208 .

With this PR service ctor methods used in program adjusted by the `gprogram` macro so they return service exposure instead of service itself
