### PR TITLE
refactor(rtl): Make sails-rtl crate self-sufficient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,7 +3402,6 @@ dependencies = [
  "gstd",
  "parity-scale-codec",
  "sails-client-gen",
- "sails-macros",
  "sails-rtl",
  "scale-info",
 ]
@@ -3693,7 +3692,6 @@ name = "rmrk-catalog-app"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
- "sails-macros",
  "sails-rtl",
  "scale-info",
 ]
@@ -3719,7 +3717,6 @@ dependencies = [
  "gstd",
  "parity-scale-codec",
  "sails-client-gen",
- "sails-macros",
  "sails-rtl",
  "scale-info",
 ]
@@ -3844,6 +3841,7 @@ dependencies = [
 name = "sails-macros-core"
 version = "0.0.1"
 dependencies = [
+ "const_format",
  "convert_case 0.6.0",
  "insta",
  "parity-scale-codec",
@@ -3866,6 +3864,7 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "primitive-types",
+ "sails-macros",
  "scale-info",
  "thiserror-no-std",
 ]
@@ -4808,8 +4807,6 @@ version = "0.1.0"
 dependencies = [
  "gstd",
  "parity-scale-codec",
- "primitive-types",
- "sails-macros",
  "sails-rtl",
  "scale-info",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,9 +4806,7 @@ name = "this-that-svc-app"
 version = "0.1.0"
 dependencies = [
  "gstd",
- "parity-scale-codec",
  "sails-rtl",
- "scale-info",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1"
+const-format = { package = "const_format", version = "0.2" }
 convert-case = { package = "convert_case", version = "0.6" }
 futures = { version = "0.3", default-features = false }
 gear-core-errors = "1.4.1"

--- a/examples/puppeteer/app/Cargo.toml
+++ b/examples/puppeteer/app/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 gstd = { workspace = true, features = ["debug"] }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 sails-rtl.workspace = true
-sails-macros.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 
 [build-dependencies]

--- a/examples/puppeteer/app/src/lib.rs
+++ b/examples/puppeteer/app/src/lib.rs
@@ -5,9 +5,9 @@ pub mod puppet;
 use core::marker::PhantomData;
 use gstd::prelude::*;
 use puppet::traits::ThisThatSvc;
-use sails_macros::gservice;
 use sails_rtl::{
     calls::{Call, Remoting},
+    gstd::gservice,
     ActorId,
 };
 

--- a/examples/rmrk/catalog/app/Cargo.toml
+++ b/examples/rmrk/catalog/app/Cargo.toml
@@ -5,6 +5,5 @@ edition = "2021"
 
 [dependencies]
 parity-scale-codec = { workspace = true, features = ["derive"] }
-sails-macros.workspace = true
 sails-rtl.workspace = true
 scale-info = { workspace = true, features = ["derive"] }

--- a/examples/rmrk/catalog/app/src/lib.rs
+++ b/examples/rmrk/catalog/app/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
-use sails_macros::{gprogram, groute};
-use sails_rtl::gstd::GStdExecContext;
+use sails_rtl::gstd::{gprogram, groute, GStdExecContext};
 use services::Catalog;
 
 // Exposed publicly because of tests which use generated data

--- a/examples/rmrk/catalog/app/src/services/mod.rs
+++ b/examples/rmrk/catalog/app/src/services/mod.rs
@@ -1,9 +1,8 @@
 use errors::Error;
 use parts::{CollectionId, Part, PartId, SlotPart};
-use sails_macros::gservice;
 use sails_rtl::{
     collections::{BTreeMap, BTreeSet},
-    gstd::ExecContext,
+    gstd::{gservice, ExecContext},
     prelude::*,
     Result as RtlResult,
 };

--- a/examples/rmrk/resource/app/Cargo.toml
+++ b/examples/rmrk/resource/app/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 gstd.workspace = true
 parity-scale-codec = { workspace = true, features = ["derive"] }
-sails-macros.workspace = true
 sails-rtl.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 

--- a/examples/rmrk/resource/app/src/lib.rs
+++ b/examples/rmrk/resource/app/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-use sails_macros::{gprogram, groute};
 use sails_rtl::gstd::{
     calls::{GStdArgs, GStdRemoting},
     events::GStdEventTrigger,
-    GStdExecContext,
+    gprogram, groute, GStdExecContext,
 };
 use services::{ResourceStorage, ResourceStorageEvent};
 

--- a/examples/rmrk/resource/app/src/services/mod.rs
+++ b/examples/rmrk/resource/app/src/services/mod.rs
@@ -1,12 +1,14 @@
 use crate::catalogs::traits::RmrkCatalog;
 use errors::{Error, Result};
 use resources::{ComposedResource, PartId, Resource, ResourceId};
-use sails_macros::gservice;
-use sails_rtl::calls::Call;
-use sails_rtl::gstd::calls::{GStdArgs, GStdRemoting};
 use sails_rtl::{
+    calls::Call,
     collections::HashMap,
-    gstd::{events::EventTrigger, ExecContext},
+    gstd::{
+        calls::{GStdArgs, GStdRemoting},
+        events::EventTrigger,
+        gservice, ExecContext,
+    },
     prelude::*,
     ActorId,
 };

--- a/examples/this-that-svc/app/Cargo.toml
+++ b/examples/this-that-svc/app/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2021"
 
 [dependencies]
 gstd = { workspace = true, features = ["debug"] }
-sails-macros.workspace = true
 sails-rtl.workspace = true
 parity-scale-codec = { workspace = true, features = ["derive"] }
-primitive-types.workspace = true
 scale-info = { workspace = true, features = ["derive"] }

--- a/examples/this-that-svc/app/Cargo.toml
+++ b/examples/this-that-svc/app/Cargo.toml
@@ -6,5 +6,3 @@ edition = "2021"
 [dependencies]
 gstd = { workspace = true, features = ["debug"] }
 sails-rtl.workspace = true
-parity-scale-codec = { workspace = true, features = ["derive"] }
-scale-info = { workspace = true, features = ["derive"] }

--- a/examples/this-that-svc/app/src/lib.rs
+++ b/examples/this-that-svc/app/src/lib.rs
@@ -46,9 +46,13 @@ impl MyService {
 
 #[allow(dead_code)]
 #[derive(Debug, Decode, TypeInfo)]
+#[codec(crate = sails_rtl::scale_codec)]
+#[scale_info(crate = sails_rtl::scale_info)]
 pub struct TupleStruct(bool);
 
 #[derive(Debug, Decode, TypeInfo)]
+#[codec(crate = sails_rtl::scale_codec)]
+#[scale_info(crate = sails_rtl::scale_info)]
 pub struct DoThatParam {
     pub p1: u32,
     pub p2: String,
@@ -56,6 +60,8 @@ pub struct DoThatParam {
 }
 
 #[derive(Debug, Decode, TypeInfo)]
+#[codec(crate = sails_rtl::scale_codec)]
+#[scale_info(crate = sails_rtl::scale_info)]
 pub enum ManyVariants {
     One,
     Two(u32),

--- a/examples/this-that-svc/app/src/lib.rs
+++ b/examples/this-that-svc/app/src/lib.rs
@@ -1,8 +1,7 @@
 #![no_std]
 
 use gstd::{debug, prelude::*};
-use primitive_types::{H256, U256};
-use sails_macros::gservice;
+use sails_rtl::{gstd::gservice, H256, U256};
 
 #[derive(Default)]
 pub struct MyService;

--- a/macros/core/Cargo.toml
+++ b/macros/core/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+const-format.workspace = true
 convert-case.workspace = true
 parity-scale-codec.workspace = true
 proc-macro-error.workspace = true

--- a/macros/core/src/lib.rs
+++ b/macros/core/src/lib.rs
@@ -24,5 +24,6 @@ pub use service::gservice;
 
 mod program;
 mod route;
+mod sails_paths;
 mod service;
 mod shared;

--- a/macros/core/src/sails_paths.rs
+++ b/macros/core/src/sails_paths.rs
@@ -1,0 +1,17 @@
+use const_format::concatcp;
+
+const SAILS: &str = "sails_rtl";
+const SAILS_SCALE_CODEC: &str = concatcp!(SAILS, "::scale_codec");
+const SAILS_SCALE_INFO: &str = concatcp!(SAILS, "::scale_info");
+
+pub(crate) fn scale_types_path() -> syn::Path {
+    syn::parse_str(SAILS).unwrap()
+}
+
+pub(crate) fn scale_codec_path() -> syn::Path {
+    syn::parse_str(SAILS_SCALE_CODEC).unwrap()
+}
+
+pub(crate) fn scale_info_path() -> syn::Path {
+    syn::parse_str(SAILS_SCALE_INFO).unwrap()
+}

--- a/macros/core/src/service.rs
+++ b/macros/core/src/service.rs
@@ -18,7 +18,10 @@
 
 //! Supporting functions and structures for the `gservice` macro.
 
-use crate::shared::{self, Func, ImplType};
+use crate::{
+    sails_paths,
+    shared::{self, Func, ImplType},
+};
 use convert_case::{Case, Casing};
 use parity_scale_codec::Encode;
 use proc_macro2::{Span, TokenStream as TokenStream2};
@@ -121,6 +124,10 @@ pub fn gservice(service_impl_tokens: TokenStream2) -> TokenStream2 {
     let message_id_ident = Ident::new("message_id", Span::call_site());
     let route_ident = Ident::new("route", Span::call_site());
 
+    let scale_types_path = sails_paths::scale_types_path();
+    let scale_codec_path = sails_paths::scale_codec_path();
+    let scale_info_path = sails_paths::scale_info_path();
+
     quote!(
         #service_impl
 
@@ -161,35 +168,47 @@ pub fn gservice(service_impl_tokens: TokenStream2) -> TokenStream2 {
         }
 
         impl #service_type_args sails_rtl::meta::ServiceMeta for #service_type_path #service_type_constraints {
-            fn commands() -> scale_info::MetaType {
-                scale_info::MetaType::new::<meta::CommandsMeta>()
+            fn commands() -> #scale_info_path ::MetaType {
+                #scale_info_path ::MetaType::new::<meta::CommandsMeta>()
             }
 
-            fn queries() -> scale_info::MetaType {
-                scale_info::MetaType::new::<meta::QueriesMeta>()
+            fn queries() -> #scale_info_path ::MetaType {
+                #scale_info_path ::MetaType::new::<meta::QueriesMeta>()
             }
 
-            fn events() -> scale_info::MetaType {
-                scale_info::MetaType::new::<meta::EventsMeta>()
+            fn events() -> #scale_info_path ::MetaType {
+                #scale_info_path ::MetaType::new::<meta::EventsMeta>()
             }
         }
 
-        #(#[derive(Decode, TypeInfo)] #invocation_params_structs)*
+        use #scale_types_path ::Decode as __ServiceDecode;
+        use #scale_types_path ::Encode as __ServiceEncode;
+        use #scale_types_path ::TypeInfo as __ServiceTypeInfo;
+
+        #(
+            #[derive(__ServiceDecode, __ServiceTypeInfo)]
+            #[codec(crate = #scale_codec_path )]
+            #[scale_info(crate = #scale_info_path )]
+            #invocation_params_structs
+        )*
 
         mod meta {
             use super::*;
 
-            #[derive(TypeInfo)]
+            #[derive(__ServiceTypeInfo)]
+            #[scale_info(crate = #scale_info_path )]
             pub enum CommandsMeta {
                 #(#commands_meta_variants),*
             }
 
-            #[derive(TypeInfo)]
+            #[derive(__ServiceTypeInfo)]
+            #[scale_info(crate = #scale_info_path )]
             pub enum QueriesMeta {
                 #(#queries_meta_variants),*
             }
 
-            #[derive(TypeInfo)]
+            #[derive(__ServiceTypeInfo)]
+            #[scale_info(crate = #scale_info_path )]
             pub enum #no_events_type {}
 
             pub type EventsMeta = #events_type;

--- a/macros/core/tests/snapshots/program__gprogram_generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -59,11 +59,12 @@ impl sails_rtl::meta::ProgramMeta for MyProgram {
             .into_iter()
     }
 }
-use sails_rtl::prelude::Decode as __ProgramDecode;
-use sails_rtl::prelude::TypeInfo as __ProgramTypeInfo;
+use sails_rtl::Decode as __ProgramDecode;
+use sails_rtl::TypeInfo as __ProgramTypeInfo;
 mod meta {
     use super::*;
     #[derive(__ProgramTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum ConstructorsMeta {}
 }
 #[cfg(target_arch = "wasm32")]

--- a/macros/core/tests/snapshots/program__gprogram_generates_handle_for_single_service_with_non_empty_route.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_handle_for_single_service_with_non_empty_route.snap
@@ -38,11 +38,12 @@ impl sails_rtl::meta::ProgramMeta for MyProgram {
         [("Service", sails_rtl::meta::AnyServiceMeta::new::<MyService>())].into_iter()
     }
 }
-use sails_rtl::prelude::Decode as __ProgramDecode;
-use sails_rtl::prelude::TypeInfo as __ProgramTypeInfo;
+use sails_rtl::Decode as __ProgramDecode;
+use sails_rtl::TypeInfo as __ProgramTypeInfo;
 mod meta {
     use super::*;
     #[derive(__ProgramTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum ConstructorsMeta {}
 }
 #[cfg(target_arch = "wasm32")]

--- a/macros/core/tests/snapshots/program__gprogram_generates_init_for_multiple_ctors.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_init_for_multiple_ctors.snap
@@ -20,14 +20,18 @@ impl sails_rtl::meta::ProgramMeta for MyProgram {
         [].into_iter()
     }
 }
-use sails_rtl::prelude::Decode as __ProgramDecode;
-use sails_rtl::prelude::TypeInfo as __ProgramTypeInfo;
+use sails_rtl::Decode as __ProgramDecode;
+use sails_rtl::TypeInfo as __ProgramTypeInfo;
 #[derive(__ProgramDecode, __ProgramTypeInfo)]
+#[codec(crate = sails_rtl::scale_codec)]
+#[scale_info(crate = sails_rtl::scale_info)]
 struct __NewParams {
     p1: u32,
     p2: String,
 }
 #[derive(__ProgramDecode, __ProgramTypeInfo)]
+#[codec(crate = sails_rtl::scale_codec)]
+#[scale_info(crate = sails_rtl::scale_info)]
 struct __New2Params {
     p2: String,
     p1: u32,
@@ -35,6 +39,7 @@ struct __New2Params {
 mod meta {
     use super::*;
     #[derive(__ProgramTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum ConstructorsMeta {
         New(__NewParams),
         New2(__New2Params),
@@ -101,4 +106,3 @@ pub mod wasm {
         gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
     }
 }
-

--- a/macros/core/tests/snapshots/program__gprogram_generates_init_for_no_ctor.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_init_for_no_ctor.snap
@@ -13,11 +13,12 @@ impl sails_rtl::meta::ProgramMeta for MyProgram {
         [].into_iter()
     }
 }
-use sails_rtl::prelude::Decode as __ProgramDecode;
-use sails_rtl::prelude::TypeInfo as __ProgramTypeInfo;
+use sails_rtl::Decode as __ProgramDecode;
+use sails_rtl::TypeInfo as __ProgramTypeInfo;
 mod meta {
     use super::*;
     #[derive(__ProgramTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum ConstructorsMeta {}
 }
 #[cfg(target_arch = "wasm32")]
@@ -69,4 +70,3 @@ pub mod wasm {
         gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
     }
 }
-

--- a/macros/core/tests/snapshots/program__gprogram_generates_init_for_single_ctor.snap
+++ b/macros/core/tests/snapshots/program__gprogram_generates_init_for_single_ctor.snap
@@ -17,9 +17,11 @@ impl sails_rtl::meta::ProgramMeta for MyProgram {
         [].into_iter()
     }
 }
-use sails_rtl::prelude::Decode as __ProgramDecode;
-use sails_rtl::prelude::TypeInfo as __ProgramTypeInfo;
+use sails_rtl::Decode as __ProgramDecode;
+use sails_rtl::TypeInfo as __ProgramTypeInfo;
 #[derive(__ProgramDecode, __ProgramTypeInfo)]
+#[codec(crate = sails_rtl::scale_codec)]
+#[scale_info(crate = sails_rtl::scale_info)]
 struct __NewParams {
     p1: u32,
     p2: String,
@@ -27,6 +29,7 @@ struct __NewParams {
 mod meta {
     use super::*;
     #[derive(__ProgramTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum ConstructorsMeta {
         New(__NewParams),
     }
@@ -86,4 +89,3 @@ pub mod wasm {
         gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
     }
 }
-

--- a/macros/core/tests/snapshots/service__gservice_works.snap
+++ b/macros/core/tests/snapshots/service__gservice_works.snap
@@ -83,36 +83,46 @@ impl sails_rtl::gstd::services::Service for SomeService {
     }
 }
 impl sails_rtl::meta::ServiceMeta for SomeService {
-    fn commands() -> scale_info::MetaType {
-        scale_info::MetaType::new::<meta::CommandsMeta>()
+    fn commands() -> sails_rtl::scale_info::MetaType {
+        sails_rtl::scale_info::MetaType::new::<meta::CommandsMeta>()
     }
-    fn queries() -> scale_info::MetaType {
-        scale_info::MetaType::new::<meta::QueriesMeta>()
+    fn queries() -> sails_rtl::scale_info::MetaType {
+        sails_rtl::scale_info::MetaType::new::<meta::QueriesMeta>()
     }
-    fn events() -> scale_info::MetaType {
-        scale_info::MetaType::new::<meta::EventsMeta>()
+    fn events() -> sails_rtl::scale_info::MetaType {
+        sails_rtl::scale_info::MetaType::new::<meta::EventsMeta>()
     }
 }
-#[derive(Decode, TypeInfo)]
+use sails_rtl::Decode as __ServiceDecode;
+use sails_rtl::Encode as __ServiceEncode;
+use sails_rtl::TypeInfo as __ServiceTypeInfo;
+#[derive(__ServiceDecode, __ServiceTypeInfo)]
+#[codec(crate = sails_rtl::scale_codec)]
+#[scale_info(crate = sails_rtl::scale_info)]
 pub struct __DoThisParams {
     p1: u32,
     p2: String,
 }
-#[derive(Decode, TypeInfo)]
+#[derive(__ServiceDecode, __ServiceTypeInfo)]
+#[codec(crate = sails_rtl::scale_codec)]
+#[scale_info(crate = sails_rtl::scale_info)]
 pub struct __ThisParams {
     p1: bool,
 }
 mod meta {
     use super::*;
-    #[derive(TypeInfo)]
+    #[derive(__ServiceTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum CommandsMeta {
         DoThis(__DoThisParams, u32),
     }
-    #[derive(TypeInfo)]
+    #[derive(__ServiceTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum QueriesMeta {
         This(__ThisParams, bool),
     }
-    #[derive(TypeInfo)]
+    #[derive(__ServiceTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum NoEvents {}
     pub type EventsMeta = NoEvents;
 }

--- a/macros/core/tests/snapshots/service__gservice_works_for_lifetimes_and_generics.snap
+++ b/macros/core/tests/snapshots/service__gservice_works_for_lifetimes_and_generics.snap
@@ -88,27 +88,35 @@ where
     T: Clone,
     TEventTrigger: EventTrigger<events::SomeEvents>,
 {
-    fn commands() -> scale_info::MetaType {
-        scale_info::MetaType::new::<meta::CommandsMeta>()
+    fn commands() -> sails_rtl::scale_info::MetaType {
+        sails_rtl::scale_info::MetaType::new::<meta::CommandsMeta>()
     }
-    fn queries() -> scale_info::MetaType {
-        scale_info::MetaType::new::<meta::QueriesMeta>()
+    fn queries() -> sails_rtl::scale_info::MetaType {
+        sails_rtl::scale_info::MetaType::new::<meta::QueriesMeta>()
     }
-    fn events() -> scale_info::MetaType {
-        scale_info::MetaType::new::<meta::EventsMeta>()
+    fn events() -> sails_rtl::scale_info::MetaType {
+        sails_rtl::scale_info::MetaType::new::<meta::EventsMeta>()
     }
 }
-#[derive(Decode, TypeInfo)]
+use sails_rtl::Decode as __ServiceDecode;
+use sails_rtl::Encode as __ServiceEncode;
+use sails_rtl::TypeInfo as __ServiceTypeInfo;
+#[derive(__ServiceDecode, __ServiceTypeInfo)]
+#[codec(crate = sails_rtl::scale_codec)]
+#[scale_info(crate = sails_rtl::scale_info)]
 pub struct __DoThisParams {}
 mod meta {
     use super::*;
-    #[derive(TypeInfo)]
+    #[derive(__ServiceTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum CommandsMeta {
         DoThis(__DoThisParams, u32),
     }
-    #[derive(TypeInfo)]
+    #[derive(__ServiceTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum QueriesMeta {}
-    #[derive(TypeInfo)]
+    #[derive(__ServiceTypeInfo)]
+    #[scale_info(crate = sails_rtl::scale_info)]
     pub enum NoEvents {}
     pub type EventsMeta = events::SomeEvents;
 }

--- a/macros/tests/ui/gservice_fails_route_fn_must_be_public.rs
+++ b/macros/tests/ui/gservice_fails_route_fn_must_be_public.rs
@@ -1,6 +1,4 @@
-use parity_scale_codec::{Decode, Encode};
-use sails_macros::{gservice, groute};
-use scale_info::TypeInfo;
+use sails_macros::{groute, gservice};
 
 struct MyService;
 

--- a/macros/tests/ui/gservice_fails_route_fn_must_be_public.stderr
+++ b/macros/tests/ui/gservice_fails_route_fn_must_be_public.stderr
@@ -1,5 +1,5 @@
 error: `groute` attribute can be applied to public methods only
-  --> tests/ui/gservice_fails_route_fn_must_be_public.rs:14:5
+  --> tests/ui/gservice_fails_route_fn_must_be_public.rs:12:5
    |
-14 |     fn this(&self, p1: bool) -> bool {
+12 |     fn this(&self, p1: bool) -> bool {
    |     ^^

--- a/macros/tests/ui/gservice_works.rs
+++ b/macros/tests/ui/gservice_works.rs
@@ -1,7 +1,8 @@
-use parity_scale_codec::{Decode, Encode};
-use sails_macros::gservice;
-use sails_rtl::{gstd::services::Service, MessageId};
-use scale_info::TypeInfo;
+use parity_scale_codec::Encode;
+use sails_rtl::{
+    gstd::{gservice, services::Service},
+    MessageId,
+};
 
 struct MyService;
 

--- a/macros/tests/ui/gservice_works_for_lifecycles_and_generics.rs
+++ b/macros/tests/ui/gservice_works_for_lifecycles_and_generics.rs
@@ -1,8 +1,8 @@
 use core::marker::PhantomData;
-use parity_scale_codec::{Decode, Encode};
-use sails_macros::gservice;
-use sails_rtl::{gstd::services::Service, MessageId};
-use scale_info::TypeInfo;
+use sails_rtl::{
+    gstd::{gservice, services::Service},
+    MessageId,
+};
 
 struct MyService<'a, T> {
     _a: PhantomData<&'a T>,

--- a/rtl/Cargo.toml
+++ b/rtl/Cargo.toml
@@ -13,6 +13,7 @@ hashbrown.workspace = true
 hex.workspace = true
 parity-scale-codec = { workspace = true, features = ["derive"] }
 primitive-types.workspace = true
+sails-macros.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 thiserror-no-std.workspace = true
 

--- a/rtl/src/calls.rs
+++ b/rtl/src/calls.rs
@@ -1,6 +1,10 @@
-use crate::errors::{Result, RtlError};
-use crate::prelude::*;
+use crate::{
+    errors::{Result, RtlError},
+    types::*,
+    Vec,
+};
 use core::{future::Future, marker::PhantomData};
+use parity_scale_codec::{Decode, Encode};
 
 pub trait Action<TArgs> {
     fn with_value(self, value: ValueUnit) -> Self;

--- a/rtl/src/gstd/mod.rs
+++ b/rtl/src/gstd/mod.rs
@@ -1,6 +1,7 @@
 use crate::{ActorId, MessageId};
 use core::cell::OnceCell;
 pub use gstd::{async_init, async_main, handle_signal, message_loop, msg, record_reply};
+pub use sails_macros::*;
 
 pub mod calls;
 pub mod events;

--- a/rtl/src/lib.rs
+++ b/rtl/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub use hex::{self};
 pub use prelude::*;
 
 pub mod calls;
@@ -8,16 +9,7 @@ pub mod gstd;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod gtest;
 pub mod prelude;
-pub mod types;
-
-pub mod hex {
-    pub use ::hex::*;
-}
-
-pub mod scale {
-    pub use parity_scale_codec::{Decode, Encode, EncodeLike};
-    pub use scale_info::TypeInfo;
-}
+mod types;
 
 pub mod meta {
     use scale_info::MetaType;

--- a/rtl/src/prelude.rs
+++ b/rtl/src/prelude.rs
@@ -47,5 +47,5 @@ pub mod ffi {
 
 pub use crate::types::*;
 
-// Reexports from third-party libraries
-pub use crate::scale::*;
+pub use parity_scale_codec::{self as scale_codec, Decode, Encode, EncodeLike};
+pub use scale_info::{self as scale_info, TypeInfo};

--- a/rtl/src/types.rs
+++ b/rtl/src/types.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
+use parity_scale_codec::{Decode, Encode};
 pub use primitive_types::*;
+use scale_info::TypeInfo;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode, TypeInfo)]
 pub struct ActorId([u8; 32]);


### PR DESCRIPTION
With this PR a user need to wire up just the `sails-rtl` crate in order to build an empty sails-based program:
1. The `gprogram`, `gservice` and `groute` macros are re-exported
2. The generated code relies on re-exported `parity-scale-codec` and `scale-info` crates

Resolves #182  .
