### PR TITLE
chore: Fix clippy - allow dead_code on field (rust 1.80)

### DIFF
--- a/rs/client-gen/src/ctor_generators.rs
+++ b/rs/client-gen/src/ctor_generators.rs
@@ -42,6 +42,7 @@ impl<'ast> Visitor<'ast> for CtorFactoryGenerator {
     fn visit_ctor(&mut self, ctor: &'ast Ctor) {
         quote_in! {self.tokens =>
             pub struct $(&self.service_name)Factory<R> {
+                #[allow(dead_code)]
                 remoting: R,
             }
 

--- a/rs/client-gen/tests/snapshots/generator__full.snap
+++ b/rs/client-gen/tests/snapshots/generator__full.snap
@@ -12,6 +12,7 @@ use sails_rs::{
     String,
 };
 pub struct ServiceFactory<R> {
+    #[allow(dead_code)]
     remoting: R,
 }
 impl<R> ServiceFactory<R> {

--- a/rs/client-gen/tests/snapshots/generator__rmrk_works.snap
+++ b/rs/client-gen/tests/snapshots/generator__rmrk_works.snap
@@ -12,6 +12,7 @@ use sails_rs::{
     String,
 };
 pub struct RmrkCatalogFactory<R> {
+    #[allow(dead_code)]
     remoting: R,
 }
 impl<R> RmrkCatalogFactory<R> {


### PR DESCRIPTION
Fix clippy
```
error: field `remoting` is never read
  --> E:\git\sails\target\debug\build\rmrk-resource-app-1f62bdc1bf23b6d4\out/rmrk_catalog.rs:11:5
   |
10 | pub struct RmrkCatalogFactory<R> {
   |            ------------------ field in this struct
11 |     remoting: R,
   |     ^^^^^^^^
```