### PR TITLE
chore: add 'gear-wasm-builder' into 'sails-rs' as an optional dep with re-export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,6 @@ dependencies = [
  "demo-walker",
  "futures",
  "gclient",
- "gear-wasm-builder",
  "gstd",
  "gtest",
  "sails-rs",
@@ -4130,7 +4129,6 @@ checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 name = "no-svcs-prog"
 version = "0.1.0"
 dependencies = [
- "gear-wasm-builder",
  "no-svcs-prog-app",
  "sails-client-gen",
  "sails-idl-gen",
@@ -5074,9 +5072,9 @@ dependencies = [
 name = "rmrk-catalog"
 version = "0.1.0"
 dependencies = [
- "gear-wasm-builder",
  "rmrk-catalog-app",
  "sails-idl-gen",
+ "sails-rs",
 ]
 
 [[package]]
@@ -5092,7 +5090,6 @@ dependencies = [
 name = "rmrk-resource"
 version = "0.1.0"
 dependencies = [
- "gear-wasm-builder",
  "gtest",
  "rmrk-catalog",
  "rmrk-resource-app",
@@ -5323,6 +5320,7 @@ dependencies = [
  "futures",
  "gclient",
  "gear-core-errors",
+ "gear-wasm-builder",
  "gprimitives",
  "gstd",
  "gtest",

--- a/examples/demo/app/Cargo.toml
+++ b/examples/demo/app/Cargo.toml
@@ -9,7 +9,7 @@ gstd.workspace = true
 sails-rs.workspace = true
 
 [build-dependencies]
-gwasm-builder.workspace = true
+sails-rs = { workspace = true, features = ["wasm-builder"] }
 
 [dev-dependencies]
 futures.workspace = true

--- a/examples/demo/app/build.rs
+++ b/examples/demo/app/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    gwasm_builder::build();
+    sails_rs::build_wasm();
 }

--- a/examples/no-svcs-prog/wasm/Cargo.toml
+++ b/examples/no-svcs-prog/wasm/Cargo.toml
@@ -8,10 +8,10 @@ no-svcs-prog-app = { path = "../app" }
 sails-rs.workspace = true
 
 [build-dependencies]
-gwasm-builder.workspace = true
 no-svcs-prog-app = { path = "../app" }
 sails-client-gen.workspace = true
 sails-idl-gen.workspace = true
+sails-rs = { workspace = true, features = ["wasm-builder"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/examples/no-svcs-prog/wasm/build.rs
+++ b/examples/no-svcs-prog/wasm/build.rs
@@ -3,7 +3,7 @@ use sails_client_gen::ClientGenerator;
 use std::{env, path::PathBuf};
 
 fn main() {
-    gwasm_builder::build();
+    sails_rs::build_wasm();
 
     let idl_file_path =
         PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("no-svcs-prog.idl");

--- a/examples/rmrk/catalog/wasm/Cargo.toml
+++ b/examples/rmrk/catalog/wasm/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 rmrk-catalog-app = { path = "../app" }
 
 [build-dependencies]
-gwasm-builder.workspace = true
 sails-idl-gen.workspace = true
-rmrk-catalog-app = { path = "../app" } # Used for generating IDL (service metadata)
+sails-rs = { workspace = true, features = ["wasm-builder"] }
+rmrk-catalog-app = { path = "../app" }                       # Used for generating IDL (service metadata)

--- a/examples/rmrk/catalog/wasm/build.rs
+++ b/examples/rmrk/catalog/wasm/build.rs
@@ -2,7 +2,7 @@ use rmrk_catalog_app::Program;
 use std::{env, path::PathBuf};
 
 fn main() {
-    gwasm_builder::build();
+    sails_rs::build_wasm();
 
     sails_idl_gen::generate_idl_to_file::<Program>(
         PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("rmrk-catalog.idl"),

--- a/examples/rmrk/resource/wasm/Cargo.toml
+++ b/examples/rmrk/resource/wasm/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 rmrk-resource-app = { path = "../app" }
 
 [build-dependencies]
-gwasm-builder.workspace = true
 rmrk-resource-app = { path = "../app" }
 sails-client-gen.workspace = true
 sails-idl-gen.workspace = true
+sails-rs = { workspace = true, features = ["wasm-builder"] }
 
 [dev-dependencies]
 gtest.workspace = true

--- a/examples/rmrk/resource/wasm/build.rs
+++ b/examples/rmrk/resource/wasm/build.rs
@@ -3,7 +3,7 @@ use sails_client_gen::ClientGenerator;
 use std::{env, path::PathBuf};
 
 fn main() {
-    gwasm_builder::build();
+    sails_rs::build_wasm();
 
     let manifest_dir_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -14,6 +14,7 @@ futures.workspace = true
 gear-core-errors.workspace = true
 gprimitives.workspace = true
 gstd.workspace = true
+gwasm-builder = { workspace = true, optional = true }
 hashbrown.workspace = true
 hex.workspace = true
 mockall = { workspace = true, optional = true }
@@ -30,3 +31,4 @@ gtest.workspace = true
 
 [features]
 mockall = ["dep:mockall"]
+wasm-builder = ["dep:gwasm-builder"]

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -4,6 +4,8 @@
 #[cfg(not(target_arch = "wasm32"))]
 extern crate std;
 
+#[cfg(feature = "wasm-builder")]
+pub use gwasm_builder::build as build_wasm;
 pub use hex::{self};
 pub use prelude::*;
 pub use spin::{self};


### PR DESCRIPTION
Makes the `sails-rs` crate even more self-sufficient