### PR TITLE
fix(js): don't use the spread operator to append to a large array

### DIFF
--- a/js/compress-parser.js
+++ b/js/compress-parser.js
@@ -7,16 +7,16 @@ const main = async () => {
 
   const compressedReadableStream = new Response(buf).body.pipeThrough(cs);
 
-  const resultArr = [];
-
   const reader = compressedReadableStream.getReader();
+
+  let resultArr = [];
 
   while (true) {
     const read = await reader.read();
 
     if (read.done) break;
 
-    resultArr.push(...read.value);
+    resultArr = resultArr.concat(Array.from(read.value));
   }
 
   const base64Bytes = Buffer.from(Uint8Array.from(resultArr).buffer).toString('base64');

--- a/js/src/parser/parser.ts
+++ b/js/src/parser/parser.ts
@@ -67,14 +67,14 @@ export class WasmParser {
     const decompressed = new Response(binaryBase64).body.pipeThrough<Uint8Array>(ds);
 
     const reader = decompressed.getReader();
-    const bytes = [];
+    let bytes = [];
 
     while (true) {
       const { value, done } = await reader.read();
 
       if (done) break;
 
-      bytes.push(...value);
+      bytes = bytes.concat(Array.from(value));
     }
 
     return new Uint8Array(bytes).buffer;


### PR DESCRIPTION
Resolves #453 .

-
-
-

@reviewer-or-team
