### PR TITLE
feat(idl-gen): allow non-existing dirs in path for 'generate_idl_to_file'

### DIFF
--- a/rs/idl-gen/src/lib.rs
+++ b/rs/idl-gen/src/lib.rs
@@ -33,6 +33,9 @@ pub mod program {
                 return Ok(());
             }
         }
+        if let Some(dir_path) = path.as_ref().parent() {
+            fs::create_dir_all(dir_path)?;
+        }
         Ok(fs::write(&path, idl_new_content)?)
     }
 }


### PR DESCRIPTION
Resolves #470  .
