### PR TITLE
feat(cli): invert params of 'new-program' in 'cargo-sails'

### DIFF
--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -9,13 +9,13 @@ enum Commands {
         path: String,
         #[arg(short, long, help = "Name of the new program")]
         name: Option<String>,
-        #[arg(long, help = "Generate client crate alongside the program")]
-        with_client: bool,
         #[arg(
             long,
-            help = "Generate program tests using 'gtest'. Implies '--with-client'"
+            help = "Disable generation of client package alongside the program. Implies '--no-gtest'"
         )]
-        with_gtest: bool,
+        no_client: bool,
+        #[arg(long, help = "Disable generation of program tests using 'gtest'")]
+        no_gtest: bool,
     },
 }
 
@@ -26,18 +26,18 @@ fn main() {
         Commands::NewProgram {
             path,
             name,
-            with_client,
-            with_gtest,
+            no_client,
+            no_gtest,
         } => {
             let program_generator = ProgramGenerator::new(path)
                 .with_name(name)
-                .with_client(with_client)
-                .with_gtest(with_gtest);
+                .with_client(!no_client)
+                .with_gtest(!no_gtest);
             program_generator.generate()
         }
     };
 
     if let Err(e) = result {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {:#}", e);
     }
 }

--- a/rs/cli/src/program.rs
+++ b/rs/cli/src/program.rs
@@ -35,11 +35,7 @@ impl ProgramGenerator {
     }
 
     pub fn with_gtest(self, with_gtest: bool) -> Self {
-        Self {
-            with_gtest,
-            with_client: self.with_client | with_gtest,
-            ..self
-        }
+        Self { with_gtest, ..self }
     }
 
     pub fn generate(self) -> Result<()> {
@@ -69,6 +65,7 @@ impl ProgramGenerator {
             destination: path,
             silent: true,
             define: vec![
+                format!("sails-cli-version={}", env!("CARGO_PKG_VERSION")),
                 format!("with-client={}", self.with_client),
                 format!("with-gtest={}", self.with_gtest),
             ],


### PR DESCRIPTION
- `--with-client` and `--with-gtest` are replaced by `--no-client` and `--no-gtest` respectively
- `cargo-cli` passes its version to template generation engine. The upcoming template version will check for compatibility.
