### PR TITLE
build: add readme to 'sails-rs' as a symlink for proper packaging

### DIFF
--- a/rs/README.md
+++ b/rs/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 #![no_std]
 
 #[cfg(feature = "mockall")]


### PR DESCRIPTION
This is required to allow building a package for crates-io. `cargo-package` moves the entire crate content into the `target\package` directory ignoring all the files outside of the original crate directory making some relative pathes broken. Currently the solution works on Unix-based systems only. For Win, it will probably require creating a win symlink (`mklink`) and use it via conditional compilation