### PR TITLE
feat(macros): propagate allow attrs for service impls and fns

### DIFF
--- a/rs/macros/core/tests/gservice.rs
+++ b/rs/macros/core/tests/gservice.rs
@@ -206,3 +206,26 @@ fn works_with_reply_with_value() {
 
     insta::assert_snapshot!(result);
 }
+
+#[test]
+fn works_with_allow_attrs() {
+    let input = quote! {
+        #[allow(warnings)]
+        #[allow(clippy::all)]
+        impl SomeService {
+            #[allow(unused)]
+            pub async fn do_this(&mut self, p1: u32, p2: String) -> u32 {
+                p1
+            }
+
+            pub fn this(&self, p1: bool) -> bool {
+                p1
+            }
+        }
+    };
+
+    let result = gservice(TokenStream::new(), input).to_string();
+    let result = prettyplease::unparse(&syn::parse_str(&result).unwrap());
+
+    insta::assert_snapshot!(result);
+}

--- a/rs/macros/core/tests/snapshots/gservice__works_with_allow_attrs.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_allow_attrs.snap
@@ -1,0 +1,174 @@
+---
+source: rs/macros/core/tests/gservice.rs
+expression: result
+---
+#[allow(warnings)]
+#[allow(clippy::all)]
+impl SomeService {
+    #[allow(unused)]
+    pub async fn do_this(&mut self, p1: u32, p2: String) -> u32 {
+        p1
+    }
+    pub fn this(&self, p1: bool) -> bool {
+        p1
+    }
+}
+pub struct Exposure<T> {
+    message_id: sails_rs::MessageId,
+    route: &'static [u8],
+    #[cfg(not(target_arch = "wasm32"))]
+    inner: Box<T>,
+    #[cfg(not(target_arch = "wasm32"))]
+    inner_ptr: *const T,
+    #[cfg(target_arch = "wasm32")]
+    inner: T,
+}
+#[allow(warnings)]
+#[allow(clippy::all)]
+impl Exposure<SomeService> {
+    #[allow(unused)]
+    pub async fn do_this(&mut self, p1: u32, p2: String) -> u32 {
+        let exposure_scope = sails_rs::gstd::services::ExposureCallScope::new(self);
+        self.inner.do_this(p1, p2).await
+    }
+    pub fn this(&self, p1: bool) -> bool {
+        let exposure_scope = sails_rs::gstd::services::ExposureCallScope::new(self);
+        self.inner.this(p1)
+    }
+    pub async fn handle(&mut self, input: &[u8]) -> (Vec<u8>, u128) {
+        self.try_handle(input)
+            .await
+            .unwrap_or_else(|| {
+                {
+                    let mut __input = input;
+                    let input = String::decode(&mut __input)
+                        .unwrap_or_else(|_| {
+                            if input.len() <= 8 {
+                                format!("0x{}", sails_rs::hex::encode(input))
+                            } else {
+                                format!(
+                                    "0x{}..{}", sails_rs::hex::encode(& input[..4]),
+                                    sails_rs::hex::encode(& input[input.len() - 4..])
+                                )
+                            }
+                        });
+                    panic!("Unknown request: {}", input)
+                }
+            })
+    }
+    pub async fn try_handle(&mut self, input: &[u8]) -> Option<(Vec<u8>, u128)> {
+        if input.starts_with(&[24u8, 68u8, 111u8, 84u8, 104u8, 105u8, 115u8]) {
+            let (output, value) = self.__do_this(&input[7usize..]).await;
+            static INVOCATION_ROUTE: [u8; 7usize] = [
+                24u8,
+                68u8,
+                111u8,
+                84u8,
+                104u8,
+                105u8,
+                115u8,
+            ];
+            return Some(([INVOCATION_ROUTE.as_ref(), &output].concat(), value));
+        }
+        if input.starts_with(&[16u8, 84u8, 104u8, 105u8, 115u8]) {
+            let (output, value) = self.__this(&input[5usize..]).await;
+            static INVOCATION_ROUTE: [u8; 5usize] = [16u8, 84u8, 104u8, 105u8, 115u8];
+            return Some(([INVOCATION_ROUTE.as_ref(), &output].concat(), value));
+        }
+        None
+    }
+    async fn __do_this(&mut self, mut input: &[u8]) -> (Vec<u8>, u128) {
+        let request = __DoThisParams::decode(&mut input)
+            .expect("Failed to decode request");
+        let result = self.do_this(request.p1, request.p2).await;
+        let value = 0u128;
+        return (result.encode(), value);
+    }
+    async fn __this(&self, mut input: &[u8]) -> (Vec<u8>, u128) {
+        let request = __ThisParams::decode(&mut input)
+            .expect("Failed to decode request");
+        let result = self.this(request.p1);
+        let value = 0u128;
+        return (result.encode(), value);
+    }
+}
+impl sails_rs::gstd::services::Exposure for Exposure<SomeService> {
+    fn message_id(&self) -> sails_rs::MessageId {
+        self.message_id
+    }
+    fn route(&self) -> &'static [u8] {
+        self.route
+    }
+}
+impl sails_rs::gstd::services::Service for SomeService {
+    type Exposure = Exposure<SomeService>;
+    fn expose(
+        self,
+        message_id: sails_rs::MessageId,
+        route: &'static [u8],
+    ) -> Self::Exposure {
+        #[cfg(not(target_arch = "wasm32"))]
+        let inner_box = Box::new(self);
+        #[cfg(not(target_arch = "wasm32"))]
+        let inner = inner_box.as_ref();
+        #[cfg(target_arch = "wasm32")]
+        let inner = &self;
+        Self::Exposure {
+            message_id,
+            route,
+            #[cfg(not(target_arch = "wasm32"))]
+            inner_ptr: inner_box.as_ref() as *const Self,
+            #[cfg(not(target_arch = "wasm32"))]
+            inner: inner_box,
+            #[cfg(target_arch = "wasm32")]
+            inner: self,
+        }
+    }
+}
+impl sails_rs::meta::ServiceMeta for SomeService {
+    fn commands() -> sails_rs::scale_info::MetaType {
+        sails_rs::scale_info::MetaType::new::<meta_in_service::CommandsMeta>()
+    }
+    fn queries() -> sails_rs::scale_info::MetaType {
+        sails_rs::scale_info::MetaType::new::<meta_in_service::QueriesMeta>()
+    }
+    fn events() -> sails_rs::scale_info::MetaType {
+        sails_rs::scale_info::MetaType::new::<meta_in_service::EventsMeta>()
+    }
+    fn base_services() -> impl Iterator<Item = sails_rs::meta::AnyServiceMeta> {
+        [].into_iter()
+    }
+}
+use sails_rs::Decode as __ServiceDecode;
+use sails_rs::Encode as __ServiceEncode;
+use sails_rs::TypeInfo as __ServiceTypeInfo;
+#[derive(__ServiceDecode, __ServiceTypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct __DoThisParams {
+    p1: u32,
+    p2: String,
+}
+#[derive(__ServiceDecode, __ServiceTypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct __ThisParams {
+    p1: bool,
+}
+mod meta_in_service {
+    use super::*;
+    #[derive(__ServiceTypeInfo)]
+    #[scale_info(crate = sails_rs::scale_info)]
+    pub enum CommandsMeta {
+        DoThis(__DoThisParams, u32),
+    }
+    #[derive(__ServiceTypeInfo)]
+    #[scale_info(crate = sails_rs::scale_info)]
+    pub enum QueriesMeta {
+        This(__ThisParams, bool),
+    }
+    #[derive(__ServiceTypeInfo)]
+    #[scale_info(crate = sails_rs::scale_info)]
+    pub enum NoEvents {}
+    pub type EventsMeta = NoEvents;
+}


### PR DESCRIPTION
Resolves #526  .
We do propagate only the `allow` attr at the moment as there might be args which can lead to undesired outcome