### PR TITLE
feat(client-gen): Add `no_derive_traits` flag to remove derive generation for PartialEq, Debug

### DIFF
--- a/rs/client-gen/src/lib.rs
+++ b/rs/client-gen/src/lib.rs
@@ -21,6 +21,7 @@ pub struct ClientGenerator<'a, S> {
     sails_path: Option<&'a str>,
     mocks_feature_name: Option<&'a str>,
     external_types: HashMap<&'a str, &'a str>,
+    no_derive_traits: bool,
     idl: S,
 }
 
@@ -47,6 +48,13 @@ impl<'a, S> ClientGenerator<'a, S> {
             ..self
         }
     }
+
+    pub fn with_no_derive_traits(self) -> Self {
+        Self {
+            no_derive_traits: true,
+            ..self
+        }
+    }
 }
 
 impl<'a> ClientGenerator<'a, IdlPath<'a>> {
@@ -55,6 +63,7 @@ impl<'a> ClientGenerator<'a, IdlPath<'a>> {
             sails_path: None,
             mocks_feature_name: None,
             external_types: HashMap::new(),
+            no_derive_traits: false,
             idl: IdlPath(idl_path),
         }
     }
@@ -79,6 +88,7 @@ impl<'a> ClientGenerator<'a, IdlPath<'a>> {
             sails_path: self.sails_path,
             mocks_feature_name: self.mocks_feature_name,
             external_types: self.external_types,
+            no_derive_traits: self.no_derive_traits,
             idl: IdlString(idl),
         }
     }
@@ -90,6 +100,7 @@ impl<'a> ClientGenerator<'a, IdlString<'a>> {
             sails_path: None,
             mocks_feature_name: None,
             external_types: HashMap::new(),
+            no_derive_traits: false,
             idl: IdlString(idl),
         }
     }
@@ -102,6 +113,7 @@ impl<'a> ClientGenerator<'a, IdlString<'a>> {
             self.mocks_feature_name,
             sails_path,
             self.external_types,
+            self.no_derive_traits,
         );
         let program = sails_idl_parser::ast::parse_idl(idl).context("Failed to parse IDL")?;
         visitor::accept_program(&program, &mut generator);

--- a/rs/client-gen/src/root_generator.rs
+++ b/rs/client-gen/src/root_generator.rs
@@ -16,6 +16,7 @@ pub(crate) struct RootGenerator<'a> {
     mocks_feature_name: Option<&'a str>,
     sails_path: &'a str,
     external_types: HashMap<&'a str, &'a str>,
+    no_derive_traits: bool,
 }
 
 impl<'a> RootGenerator<'a> {
@@ -24,6 +25,7 @@ impl<'a> RootGenerator<'a> {
         mocks_feature_name: Option<&'a str>,
         sails_path: &'a str,
         external_types: HashMap<&'a str, &'a str>,
+        no_derive_traits: bool,
     ) -> Self {
         let mut tokens = quote! {
             #[allow(unused_imports)]
@@ -47,6 +49,7 @@ impl<'a> RootGenerator<'a> {
             mocks_feature_name,
             sails_path,
             external_types,
+            no_derive_traits,
         }
     }
 
@@ -149,7 +152,8 @@ impl<'a, 'ast> Visitor<'ast> for RootGenerator<'a> {
         if self.external_types.contains_key(t.name()) {
             return;
         }
-        let mut type_gen = TopLevelTypeGenerator::new(t.name(), self.sails_path);
+        let mut type_gen =
+            TopLevelTypeGenerator::new(t.name(), self.sails_path, self.no_derive_traits);
         type_gen.visit_type(t);
         self.tokens.extend(type_gen.finalize());
     }

--- a/rs/client-gen/tests/generator.rs
+++ b/rs/client-gen/tests/generator.rs
@@ -224,6 +224,7 @@ fn test_external_types() {
     let code = ClientGenerator::from_idl(IDL)
         .with_sails_crate("my_crate::sails")
         .with_external_type("MyParam", "my_crate::MyParam")
+        .with_no_derive_traits()
         .generate("Service")
         .expect("generate client");
     insta::assert_snapshot!(code);

--- a/rs/client-gen/tests/snapshots/generator__external_types.snap
+++ b/rs/client-gen/tests/snapshots/generator__external_types.snap
@@ -63,7 +63,7 @@ pub mod service {
         }
     }
 }
-#[derive(PartialEq, Debug, Encode, Decode, TypeInfo)]
+#[derive(Encode, Decode, TypeInfo)]
 #[codec(crate = my_crate::sails::scale_codec)]
 #[scale_info(crate = my_crate::sails::scale_info)]
 pub enum MyParam2 {


### PR DESCRIPTION
Resolves #556  .
