### PR TITLE
fix(build): CI wabt-sys build error `Compatibility with CMake < 3.5 has been removed from CMake.`

### DIFF
--- a/.github/workflows/rs-ci.yml
+++ b/.github/workflows/rs-ci.yml
@@ -26,6 +26,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
 jobs:
   check:

--- a/.github/workflows/rs-ci.yml
+++ b/.github/workflows/rs-ci.yml
@@ -26,6 +26,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # fix wabt build, remove after bump Gear version https://github.com/gear-tech/gear/pull/4494
   CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
 jobs:
@@ -66,6 +67,5 @@ jobs:
       gear_node_version: 1.7.1
 
   test-cli:
-    if: false
     name: Run CLI Tests
     uses: ./.github/workflows/rs-run-cli-tests.yml

--- a/.github/workflows/rs-run-cli-tests.yml
+++ b/.github/workflows/rs-run-cli-tests.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: false
 
+env:
+  CARGO_TERM_COLOR: always
+  # fix wabt build, remove after bump Gear version https://github.com/gear-tech/gear/pull/4494
+  CMAKE_POLICY_VERSION_MINIMUM: 3.5
+
 jobs:
   test_cli:
     name: Run CLI Tests

--- a/.github/workflows/rs-run-ws-tests.yml
+++ b/.github/workflows/rs-run-ws-tests.yml
@@ -12,6 +12,11 @@ on:
         required: true
         type: string
 
+env:
+  CARGO_TERM_COLOR: always
+  # fix wabt build, remove after bump Gear version https://github.com/gear-tech/gear/pull/4494
+  CMAKE_POLICY_VERSION_MINIMUM: 3.5
+
 jobs:
   test_ws:
     name: Run Workspace Tests


### PR DESCRIPTION
Resolves wabt CI build

NOTE: remove after bump Gear version https://github.com/gear-tech/gear/pull/4494