### PR TITLE
fix: fn returns `CommandReply<()>` with value must send manual reply

### DIFF
--- a/examples/demo/app/src/lib.rs
+++ b/examples/demo/app/src/lib.rs
@@ -144,11 +144,13 @@ mod tests {
         Syscall::with_message_id(MessageId::from(1));
 
         let mut service_exposure = program.value_fee();
-        let (data, value) = service_exposure.do_something_and_take_fee().to_tuple();
+        let (_, value) = service_exposure
+            .do_something_and_take_fee()
+            .unwrap()
+            .to_tuple();
 
         // Assert
         assert_eq!(6, service_exposure.route_idx());
-        assert!(data);
         assert_eq!(value, message_value - 10_000_000_000_000);
 
         // Next call

--- a/examples/demo/app/src/value_fee/mod.rs
+++ b/examples/demo/app/src/value_fee/mod.rs
@@ -20,25 +20,25 @@ impl FeeService {
 
 #[service(events = FeeEvents)]
 impl FeeService {
-    /// Return flag if fee taken and remain value,
+    /// Return `Ok(())` if fee taken and remain value,
     /// using special type `CommandReply<T>`
-    #[export]
-    pub fn do_something_and_take_fee(&mut self) -> CommandReply<bool> {
+    #[export(unwrap_result)]
+    pub fn do_something_and_take_fee(&mut self) -> Result<CommandReply<()>, String> {
         let value = Syscall::message_value();
         if value == 0 {
-            return false.into();
+            return Ok(().into());
         }
         if value < self.fee {
-            panic!("Not enough value");
+            return Err("Not enough value".to_string());
         }
         self.emit_event(FeeEvents::Withheld(self.fee)).unwrap();
         let to_return = value - self.fee;
         if to_return < Syscall::env_vars().existential_deposit {
             // return zero value with reply
-            true.into()
+            Ok(().into())
         } else {
             // return remaining value with reply
-            CommandReply::new(true).with_value(to_return)
+            Ok(CommandReply::new(()).with_value(to_return))
         }
     }
 }
@@ -56,10 +56,9 @@ mod tests {
         let mut fee_service = FeeService::new(100).expose(1); // fee = 100
 
         // Act: invoke fee service.
-        let (data, value) = fee_service.do_something_and_take_fee().to_tuple();
+        let (_, value) = fee_service.do_something_and_take_fee().unwrap().to_tuple();
 
-        // Assert: should return false with no extra value.
-        assert!(!data);
+        // Assert: should return `Ok(())` with no extra value.
         assert_eq!(value, 0);
     }
 
@@ -72,7 +71,7 @@ mod tests {
         let mut fee_service = FeeService::new(200).expose(1); // fee = 200
 
         // Act: this should panic because transferred value < fee.
-        let _ = fee_service.do_something_and_take_fee();
+        let _ = fee_service.do_something_and_take_fee().unwrap();
     }
 
     #[test]
@@ -82,10 +81,9 @@ mod tests {
         let mut fee_service = FeeService::new(100).expose(1);
 
         // Act: fee is taken and remaining value is too small.
-        let (data, value) = fee_service.do_something_and_take_fee().to_tuple();
+        let (_, value) = fee_service.do_something_and_take_fee().unwrap().to_tuple();
 
-        // Assert: reply indicates success (true) but without carrying extra value.
-        assert!(data);
+        // Assert: reply `Ok(())` but without carrying extra value.
         assert_eq!(value, 0);
     }
 
@@ -99,11 +97,10 @@ mod tests {
         let mut fee_service = FeeService::new(fee).expose(1);
 
         // Act: fee is taken and the remaining value is passed along.
-        let (data, value) = fee_service.do_something_and_take_fee().to_tuple();
+        let (_, value) = fee_service.do_something_and_take_fee().unwrap().to_tuple();
 
-        // Assert: reply indicates success (true) and carries the remaining value (message_value - fee)
+        // Assert: reply `Ok(())` and carries the remaining value (message_value - fee)
         // in its value field.
-        assert!(data);
         assert_eq!(value, message_value - fee);
     }
 }

--- a/examples/demo/app/tests/gclient.rs
+++ b/examples/demo/app/tests/gclient.rs
@@ -274,17 +274,16 @@ async fn value_fee_works() {
     // Act
 
     // Use generated client code to call `do_something_and_take_fee` method with zero value
-    let result = client.do_something_and_take_fee().await.unwrap();
-    assert!(!result);
+    client.do_something_and_take_fee().await.unwrap().unwrap();
 
     // Use generated client code to call `do_something_and_take_fee` method with value
-    let result = client
+    client
         .do_something_and_take_fee()
         .with_value(15_000_000_000_000)
         .await
+        .unwrap()
         .unwrap();
 
-    assert!(result);
     let fee = 10_000_000_000_000;
     let balance = gear_api.free_balance(admin_id).await.unwrap();
     dbg!(initial_balance, balance, initial_balance - balance - fee);

--- a/examples/demo/app/tests/gtest.rs
+++ b/examples/demo/app/tests/gtest.rs
@@ -510,17 +510,16 @@ async fn value_fee_works() {
     // Act
 
     // Use generated client code to call `do_something_and_take_fee` method with zero value
-    let result = client.do_something_and_take_fee().await.unwrap();
-    assert!(!result);
+    client.do_something_and_take_fee().await.unwrap().unwrap();
 
     // Use generated client code to call `do_something_and_take_fee` method with value
-    let result = client
+    client
         .do_something_and_take_fee()
         .with_value(15_000_000_000_000)
         .await
+        .unwrap()
         .unwrap();
 
-    assert!(result);
     let balance = env.system().balance_of(ActorId::from(ACTOR_ID));
     // fee is 10_000_000_000_000 + spent gas
     // initial_balance - balance = 10_329_809_407_200

--- a/examples/demo/client/demo_client.idl
+++ b/examples/demo/client/demo_client.idl
@@ -120,14 +120,14 @@ service ThisThat@0x381e13fdd02d675f {
     }
 }
 
-service ValueFee@0x41c1080b4e1e8dc5 {
+service ValueFee@0x61261a86528bf9d5 {
     events {
         Withheld(u128),
     }
     functions {
-        /// Return flag if fee taken and remain value,
+        /// Return `Ok(())` if fee taken and remain value,
         /// using special type `CommandReply<T>`
-        DoSomethingAndTakeFee() -> bool;
+        DoSomethingAndTakeFee() throws String;
     }
 }
 
@@ -182,7 +182,7 @@ program DemoClient {
         Dog@0x061b5337bdb0e35b,
         References@0xdac2abd57442a5fa,
         ThisThat@0x381e13fdd02d675f,
-        ValueFee@0x41c1080b4e1e8dc5,
+        ValueFee@0x61261a86528bf9d5,
         Validator@0x4e78bafffdb4fb1c,
         Chaos@0xf0c8c80dfabf72d5,
         Chain@0x01fcbe183e2199b0,

--- a/examples/demo/client/src/demo_client.rs
+++ b/examples/demo/client/src/demo_client.rs
@@ -701,7 +701,7 @@ pub mod value_fee {
 
     pub trait ValueFee {
         type Env: sails_rs::client::GearEnv;
-        /// Return flag if fee taken and remain value,
+        /// Return `Ok(())` if fee taken and remain value,
         /// using special type `CommandReply<T>`
         fn do_something_and_take_fee(
             &mut self,
@@ -712,7 +712,7 @@ pub mod value_fee {
 
     impl sails_rs::client::Identifiable for ValueFeeImpl {
         const INTERFACE_ID: sails_rs::InterfaceId =
-            sails_rs::InterfaceId::from_bytes_8([65, 193, 8, 11, 78, 30, 141, 197]);
+            sails_rs::InterfaceId::from_bytes_8([97, 38, 26, 134, 82, 139, 249, 213]);
     }
 
     impl<E: sails_rs::client::GearEnv> ValueFee for sails_rs::client::Service<ValueFeeImpl, E> {
@@ -726,7 +726,7 @@ pub mod value_fee {
 
     pub mod io {
         use super::*;
-        sails_rs::io_struct_impl!(DoSomethingAndTakeFee () -> bool, 0, <super::ValueFeeImpl as sails_rs::client::Identifiable>::INTERFACE_ID);
+        sails_rs::io_struct_impl!(DoSomethingAndTakeFee () -> () | String, 0, <super::ValueFeeImpl as sails_rs::client::Identifiable>::INTERFACE_ID);
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_allow_attrs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_allow_attrs.snap
@@ -81,6 +81,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -113,6 +115,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_basics.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_basics.snap
@@ -78,6 +78,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -110,6 +112,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_crate_path.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_crate_path.snap
@@ -78,6 +78,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -110,6 +112,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_docs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_docs.snap
@@ -81,6 +81,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -113,6 +115,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_events.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_events.snap
@@ -82,6 +82,8 @@ impl MyServiceWithEventsExposure<MyServiceWithEvents> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -102,6 +104,8 @@ impl MyServiceWithEventsExposure<MyServiceWithEvents> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_export.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_export.snap
@@ -82,6 +82,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -130,6 +132,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends.snap
@@ -107,6 +107,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends_and_lifetimes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends_and_lifetimes.snap
@@ -99,6 +99,8 @@ impl<'a> ExtendedWithLifetimeExposure<ExtendedWithLifetime<'a>> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -121,6 +123,8 @@ impl<'a> ExtendedWithLifetimeExposure<ExtendedWithLifetime<'a>> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_events.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_events.snap
@@ -81,6 +81,8 @@ where
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_generics.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_generics.snap
@@ -80,6 +80,8 @@ where
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_methods_with_lifetimes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_methods_with_lifetimes.snap
@@ -105,6 +105,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -125,6 +127,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -145,6 +149,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -177,6 +183,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -197,6 +205,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
@@ -78,6 +78,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -113,6 +115,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if true && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_special_lifetimes_and_events.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_special_lifetimes_and_events.snap
@@ -82,6 +82,8 @@ where
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/src/service/exposure.rs
+++ b/rs/macros/core/src/service/exposure.rs
@@ -146,6 +146,8 @@ impl ServiceBuilder<'_> {
                     self.route_idx,
                     |encoded_result| result_handler(encoded_result, value),
                 );
+            } else if #reply_with_value && value > 0 {
+                result_handler(&[], value);
             }
             return Some(());
         }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_all_override_variants.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_all_override_variants.snap
@@ -113,6 +113,8 @@ impl InheritedServiceExposure<InheritedService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -140,6 +142,8 @@ impl InheritedServiceExposure<InheritedService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -159,6 +163,8 @@ impl InheritedServiceExposure<InheritedService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_allow_attrs.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_allow_attrs.snap
@@ -81,6 +81,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -113,6 +115,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_basics.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_basics.snap
@@ -78,6 +78,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -110,6 +112,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_crate_path.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_crate_path.snap
@@ -78,6 +78,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -110,6 +112,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_docs.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_docs.snap
@@ -81,6 +81,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -113,6 +115,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_events.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_events.snap
@@ -82,6 +82,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -102,6 +104,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_export.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_export.snap
@@ -82,6 +82,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -130,6 +132,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_extends.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_extends.snap
@@ -107,6 +107,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_extends_and_lifetimes.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_extends_and_lifetimes.snap
@@ -99,6 +99,8 @@ impl<'a> ExtendedLifetimeExposure<ExtendedLifetime<'a>> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -121,6 +123,8 @@ impl<'a> ExtendedLifetimeExposure<ExtendedLifetime<'a>> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_events.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_events.snap
@@ -81,6 +81,8 @@ where
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_generics.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_generics.snap
@@ -80,6 +80,8 @@ where
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_methods_with_lifetimes.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_methods_with_lifetimes.snap
@@ -105,6 +105,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -125,6 +127,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -145,6 +149,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -177,6 +183,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -197,6 +205,8 @@ impl ReferenceServiceExposure<ReferenceService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_mixed_methods.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_mixed_methods.snap
@@ -119,6 +119,8 @@ impl InheritedServiceExposure<InheritedService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -139,6 +141,8 @@ impl InheritedServiceExposure<InheritedService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -159,6 +163,8 @@ impl InheritedServiceExposure<InheritedService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_overrides.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_overrides.snap
@@ -107,6 +107,8 @@ impl InheritedServiceExposure<InheritedService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -134,6 +136,8 @@ impl InheritedServiceExposure<InheritedService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_reply_with_value.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_reply_with_value.snap
@@ -78,6 +78,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }
@@ -113,6 +115,8 @@ impl SomeServiceExposure<SomeService> {
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if true && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_special_lifetimes_and_events.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_special_lifetimes_and_events.snap
@@ -82,6 +82,8 @@ where
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
                     );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
                 }
                 return Some(());
             }


### PR DESCRIPTION
Resolves #1253 