### PR TITLE
feat: add #[sails_type] attribute macro to simplify dervive

### DIFF
--- a/benchmarks/alloc-stress/src/lib.rs
+++ b/benchmarks/alloc-stress/src/lib.rs
@@ -12,9 +12,7 @@ impl AllocStressService {
     }
 }
 
-#[derive(TypeInfo, Encode, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
 pub struct AllocStressResult {
     pub inner: Vec<u8>,
 }

--- a/benchmarks/compute-stress/src/lib.rs
+++ b/benchmarks/compute-stress/src/lib.rs
@@ -30,9 +30,7 @@ fn fibonacci(n: u32) -> u32 {
     }
 }
 
-#[derive(TypeInfo, Encode, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
 pub struct ComputeStressResult {
     pub res: u32,
 }

--- a/benchmarks/ping-pong/app/src/lib.rs
+++ b/benchmarks/ping-pong/app/src/lib.rs
@@ -7,9 +7,8 @@ pub mod client {
 use client::{PingPong as _, ping_pong_service::PingPongService as _};
 use sails_rs::{client::*, prelude::*};
 
-#[derive(Debug, Clone, Copy, Decode, Encode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Debug, Clone, Copy)]
 pub enum PingPongPayload {
     Start(ActorId),
     Ping,

--- a/benchmarks/ping-pong/app/src/ping_pong_client.rs
+++ b/benchmarks/ping-pong/app/src/ping_pong_client.rs
@@ -50,10 +50,8 @@ pub mod io {
 pub mod ping_pong_service {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum PingPongPayload {
         Start(ActorId),
         Ping,

--- a/benchmarks/ping-pong/client/ping_pong.idl
+++ b/benchmarks/ping-pong/client/ping_pong.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service PingPongService@0x6a72968a4c62e7d7 {
     functions {

--- a/benchmarks/src/alloc_stress_program.rs
+++ b/benchmarks/src/alloc_stress_program.rs
@@ -46,10 +46,8 @@ pub mod io {
 pub mod alloc_stress {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct AllocStressResult {
         pub inner: Vec<u8>,
     }

--- a/benchmarks/src/compute_stress_program.rs
+++ b/benchmarks/src/compute_stress_program.rs
@@ -52,10 +52,8 @@ pub mod io {
 pub mod compute_stress {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ComputeStressResult {
         pub res: u32,
     }

--- a/examples/aggregator/app/src/msg_tracker.rs
+++ b/examples/aggregator/app/src/msg_tracker.rs
@@ -1,9 +1,8 @@
 use sails_rs::collections::BTreeMap;
 use sails_rs::prelude::*;
 
-#[derive(Clone, Encode, Decode, TypeInfo, ReflectHash, PartialEq, Debug)]
-#[reflect_hash(crate = sails_rs::sails_reflect_hash)]
-#[codec(crate = sails_rs::scale_codec)]
+#[sails_type]
+#[derive(Clone, PartialEq, Debug)]
 pub enum OpStatus {
     Started,
     Step1,

--- a/examples/aggregator/client/aggregator_client.idl
+++ b/examples/aggregator/client/aggregator_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service Aggregator@0x8e5b7b94507d0323 {
     functions {

--- a/examples/aggregator/client/src/aggregator_client.rs
+++ b/examples/aggregator/client/src/aggregator_client.rs
@@ -52,10 +52,8 @@ pub mod io {
 pub mod aggregator {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum OpStatus {
         Started,
         Step1,

--- a/examples/demo/app/src/counter/mod.rs
+++ b/examples/demo/app/src/counter/mod.rs
@@ -15,9 +15,8 @@ impl CounterData {
 
 // Service event type definition.
 #[event]
-#[derive(Clone, Debug, PartialEq, Encode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq)]
 pub enum CounterEvents {
     /// Emitted when a new value is added to the counter
     Added(u32),

--- a/examples/demo/app/src/dog/mod.rs
+++ b/examples/demo/app/src/dog/mod.rs
@@ -3,9 +3,8 @@ use demo_walker::WalkerService;
 use sails_rs::prelude::*;
 
 #[event]
-#[derive(Clone, Debug, PartialEq, Encode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq)]
 pub enum DogEvents {
     Barked,
 }

--- a/examples/demo/app/src/references/mod.rs
+++ b/examples/demo/app/src/references/mod.rs
@@ -97,7 +97,6 @@ impl<'t> ReferenceService<'t> {
     }
 }
 
-#[derive(Debug, Encode, Decode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs::sails_reflect_hash)]
+#[sails_type]
+#[derive(Debug)]
 pub struct ReferenceCount(u32);

--- a/examples/demo/app/src/this_that/mod.rs
+++ b/examples/demo/app/src/this_that/mod.rs
@@ -58,23 +58,20 @@ impl MyService {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Decode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs::sails_reflect_hash)]
+#[sails_type]
+#[derive(Debug)]
 pub struct TupleStruct(bool);
 
-#[derive(Debug, Decode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs::sails_reflect_hash)]
+#[sails_type]
+#[derive(Debug)]
 pub struct DoThatParam {
     pub p1: NonZeroU32,
     pub p2: ActorId,
     pub p3: ManyVariants,
 }
 
-#[derive(Debug, Decode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs::sails_reflect_hash)]
+#[sails_type]
+#[derive(Debug)]
 pub enum ManyVariants {
     One,
     Two(u32),
@@ -84,9 +81,8 @@ pub enum ManyVariants {
     Six((u32,)),
 }
 
-#[derive(Debug, Encode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs::sails_reflect_hash)]
+#[sails_type]
+#[derive(Debug)]
 pub enum ManyVariantsReply {
     One,
     Two,

--- a/examples/demo/app/src/validator/mod.rs
+++ b/examples/demo/app/src/validator/mod.rs
@@ -21,9 +21,8 @@ impl<'a> Validator<'a> {
     }
 }
 
-#[derive(Debug, Encode, Decode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs::sails_reflect_hash)]
+#[sails_type]
+#[derive(Debug)]
 pub enum ValidationError {
     TooSmall,
     TooBig,

--- a/examples/demo/app/src/value_fee/mod.rs
+++ b/examples/demo/app/src/value_fee/mod.rs
@@ -1,9 +1,8 @@
 use sails_rs::prelude::*;
 
 #[event]
-#[derive(Clone, Debug, PartialEq, Encode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq)]
 pub enum FeeEvents {
     Withheld(ValueUnit),
 }

--- a/examples/demo/client/demo_client.idl
+++ b/examples/demo/client/demo_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service PingPong@0x6d0eb40dde4038f7 {
     functions {

--- a/examples/demo/client/src/demo_client.rs
+++ b/examples/demo/client/src/demo_client.rs
@@ -211,9 +211,8 @@ pub mod counter {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = sails_rs::scale_codec)]
-        #[reflect_hash(crate = sails_rs)]
+        #[sails_rs::sails_type(crate = sails_rs)]
+        #[derive(PartialEq, Debug)]
         pub enum CounterEvents {
             /// Emitted when a new value is added to the counter
             #[codec(index = 0)]
@@ -358,9 +357,8 @@ pub mod walker_service {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = sails_rs::scale_codec)]
-        #[reflect_hash(crate = sails_rs)]
+        #[sails_rs::sails_type(crate = sails_rs)]
+        #[derive(PartialEq, Debug)]
         pub enum WalkerServiceEvents {
             #[codec(index = 0)]
             Walked { from: (i32, i32), to: (i32, i32) },
@@ -459,9 +457,8 @@ pub mod dog {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = sails_rs::scale_codec)]
-        #[reflect_hash(crate = sails_rs)]
+        #[sails_rs::sails_type(crate = sails_rs)]
+        #[derive(PartialEq, Debug)]
         pub enum DogEvents {
             #[codec(index = 0)]
             Barked,
@@ -515,10 +512,8 @@ pub mod dog {
 pub mod references {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ReferenceCount(pub u32);
 
     pub trait References {
@@ -607,19 +602,15 @@ pub mod references {
 pub mod this_that {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct DoThatParam {
         pub p1: NonZeroU32,
         pub p2: ActorId,
         pub p3: ManyVariants,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ManyVariants {
         One,
         Two(u32),
@@ -628,10 +619,8 @@ pub mod this_that {
         Five(String, H256),
         Six((u32,)),
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ManyVariantsReply {
         One,
         Two,
@@ -640,10 +629,8 @@ pub mod this_that {
         Five,
         Six,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct TupleStruct(pub bool);
 
     pub trait ThisThat {
@@ -762,9 +749,8 @@ pub mod value_fee {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = sails_rs::scale_codec)]
-        #[reflect_hash(crate = sails_rs)]
+        #[sails_rs::sails_type(crate = sails_rs)]
+        #[derive(PartialEq, Debug)]
         pub enum ValueFeeEvents {
             #[codec(index = 0)]
             Withheld(u128),
@@ -818,10 +804,8 @@ pub mod value_fee {
 pub mod validator {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ValidationError {
         TooSmall,
         TooBig,

--- a/examples/demo/walker/src/lib.rs
+++ b/examples/demo/walker/src/lib.rs
@@ -15,9 +15,7 @@ impl WalkerData {
 }
 
 #[event]
-#[derive(TypeInfo, Encode, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
 pub enum WalkerEvents {
     Walked { from: (i32, i32), to: (i32, i32) },
 }

--- a/examples/event-routes/app/src/lib.rs
+++ b/examples/event-routes/app/src/lib.rs
@@ -3,9 +3,8 @@
 use sails_rs::{gstd, prelude::*};
 
 #[event]
-#[derive(Clone, Debug, PartialEq, Encode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Events {
     Start,
     End,

--- a/examples/inspector/client/inspector_client.idl
+++ b/examples/inspector/client/inspector_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service Inspector@0xdf7978e4f1d11ddd {
     functions {

--- a/examples/inspector/client/src/inspector_client.rs
+++ b/examples/inspector/client/src/inspector_client.rs
@@ -63,10 +63,8 @@ pub mod io {
 pub mod inspector {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ValidationError {
         TooSmall,
         TooBig,

--- a/examples/no-svcs-prog/wasm/no_svcs_prog.idl
+++ b/examples/no-svcs-prog/wasm/no_svcs_prog.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 program NoSvcsProg {
     constructors {

--- a/examples/partial-idl/app/src/lib.rs
+++ b/examples/partial-idl/app/src/lib.rs
@@ -2,9 +2,8 @@
 use sails_rs::prelude::*;
 
 #[sails_rs::event]
-#[derive(Clone, Debug, PartialEq, Encode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PartialIdlEvents {
     FirstDone,
     SecondDone(u32),

--- a/examples/partial-idl/client/src/partial_idl_client.rs
+++ b/examples/partial-idl/client/src/partial_idl_client.rs
@@ -84,9 +84,8 @@ pub mod partial_idl_service {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = sails_rs::scale_codec)]
-        #[reflect_hash(crate = sails_rs)]
+        #[sails_rs::sails_type(crate = sails_rs)]
+        #[derive(PartialEq, Debug)]
         pub enum PartialIdlServiceEvents {
             #[codec(index = 2)]
             ThirdDone(String),

--- a/examples/redirect/client/redirect_client.idl
+++ b/examples/redirect/client/redirect_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service Redirect@0xba58dee1cb75511e {
     functions {

--- a/examples/redirect/proxy-client/redirect_proxy_client.idl
+++ b/examples/redirect/proxy-client/redirect_proxy_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service Proxy@0x73843476ff137c7e {
     functions {

--- a/examples/rmrk/catalog/app/src/services/errors.rs
+++ b/examples/rmrk/catalog/app/src/services/errors.rs
@@ -1,8 +1,6 @@
-use sails_rs::{Encode, ReflectHash, TypeInfo};
+use sails_rs::prelude::*;
 
-#[derive(Encode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
 pub enum Error {
     PartIdCantBeZero,
     BadConfig,

--- a/examples/rmrk/catalog/app/src/services/parts.rs
+++ b/examples/rmrk/catalog/app/src/services/parts.rs
@@ -5,17 +5,15 @@ pub type ZIndex = u32;
 
 pub type PartId = u32;
 
-#[derive(Decode, Encode, TypeInfo, Clone, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone)]
 pub enum Part {
     Fixed(FixedPart),
     Slot(SlotPart),
 }
 
-#[derive(Decode, Encode, TypeInfo, Clone, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone)]
 pub struct FixedPart {
     /// An optional zIndex of base part layer.
     /// specifies the stack order of an element.
@@ -26,9 +24,8 @@ pub struct FixedPart {
     pub metadata_uri: String,
 }
 
-#[derive(Decode, Encode, TypeInfo, Clone, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone)]
 pub struct SlotPart {
     /// Array of whitelisted collections that can be equipped in the given slot. Used with slot parts only.
     pub equippable: Vec<CollectionId>,

--- a/examples/rmrk/catalog/wasm/rmrk-catalog.idl
+++ b/examples/rmrk/catalog/wasm/rmrk-catalog.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service RmrkCatalog@0xb810a541ab5d5389 {
     functions {

--- a/examples/rmrk/resource/app/src/rmrk_catalog.rs
+++ b/examples/rmrk/resource/app/src/rmrk_catalog.rs
@@ -47,10 +47,8 @@ pub mod io {
 pub mod rmrk_catalog {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum Error {
         PartIdCantBeZero,
         BadConfig,
@@ -60,10 +58,8 @@ pub mod rmrk_catalog {
         WrongPartFormat,
         NotAllowedToCall,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct FixedPart {
         /// An optional zIndex of base part layer.
         /// specifies the stack order of an element.
@@ -72,18 +68,14 @@ pub mod rmrk_catalog {
         /// The metadata URI of the part.
         pub metadata_uri: String,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum Part {
         Fixed(FixedPart),
         Slot(SlotPart),
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct SlotPart {
         /// Array of whitelisted collections that can be equipped in the given slot. Used with slot parts only.
         pub equippable: Vec<ActorId>,

--- a/examples/rmrk/resource/app/src/services/errors.rs
+++ b/examples/rmrk/resource/app/src/services/errors.rs
@@ -2,9 +2,8 @@ use sails_rs::prelude::*;
 
 pub type Result<T, E = Error> = sails_rs::Result<T, E>;
 
-#[derive(Encode, Decode, TypeInfo, Debug, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Debug)]
 pub enum Error {
     NotAuthorized,
     ZeroResourceId,

--- a/examples/rmrk/resource/app/src/services/mod.rs
+++ b/examples/rmrk/resource/app/src/services/mod.rs
@@ -22,9 +22,7 @@ struct ResourceStorageData {
 
 // Service event type definition
 #[event]
-#[derive(TypeInfo, Encode, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
 pub enum ResourceStorageEvent {
     ResourceAdded {
         resource_id: ResourceId,

--- a/examples/rmrk/resource/app/src/services/resources.rs
+++ b/examples/rmrk/resource/app/src/services/resources.rs
@@ -4,18 +4,16 @@ pub type PartId = u32;
 
 pub type ResourceId = u8;
 
-#[derive(Decode, Encode, TypeInfo, Clone, Debug, PartialEq, Eq, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Resource {
     Basic(BasicResource),
     Slot(SlotResource),
     Composed(ComposedResource),
 }
 
-#[derive(Decode, Encode, TypeInfo, Clone, Debug, PartialEq, Eq, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BasicResource {
     /// URI like IPFS hash
     pub src: String,
@@ -28,9 +26,8 @@ pub struct BasicResource {
     pub metadata_uri: String,
 }
 
-#[derive(Decode, Encode, TypeInfo, Clone, Debug, PartialEq, Eq, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ComposedResource {
     /// URI like ipfs hash
     pub src: String,
@@ -49,9 +46,8 @@ pub struct ComposedResource {
     pub parts: Vec<PartId>,
 }
 
-#[derive(Decode, Encode, TypeInfo, Clone, Debug, PartialEq, Eq, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SlotResource {
     /// URI like ipfs hash
     pub src: String,

--- a/examples/rmrk/resource/wasm/src/rmrk_resource.rs
+++ b/examples/rmrk/resource/wasm/src/rmrk_resource.rs
@@ -50,10 +50,8 @@ pub mod io {
 pub mod rmrk_resource {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum Error {
         NotAuthorized,
         ZeroResourceId,
@@ -62,19 +60,15 @@ pub mod rmrk_resource {
         WrongResourceType,
         PartNotFound,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum Resource {
         Basic(BasicResource),
         Slot(SlotResource),
         Composed(ComposedResource),
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct BasicResource {
         /// URI like IPFS hash
         pub src: String,
@@ -84,10 +78,8 @@ pub mod rmrk_resource {
         /// Reference to IPFS location of metadata
         pub metadata_uri: String,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct SlotResource {
         /// URI like ipfs hash
         pub src: String,
@@ -100,10 +92,8 @@ pub mod rmrk_resource {
         /// If the resource has the slot property, it was designed to fit into a specific Base's slot.
         pub slot: u32,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ComposedResource {
         /// URI like ipfs hash
         pub src: String,
@@ -175,9 +165,8 @@ pub mod rmrk_resource {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = sails_rs::scale_codec)]
-        #[reflect_hash(crate = sails_rs)]
+        #[sails_rs::sails_type(crate = sails_rs)]
+        #[derive(PartialEq, Debug)]
         pub enum RmrkResourceEvents {
             #[codec(index = 0)]
             PartAdded { resource_id: u8, part_id: u32 },

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -32,7 +32,7 @@ sails-client-gen-v2 = { workspace = true, optional = true }
 sails-idl-embed = { workspace = true, optional = true }
 sails-idl-gen = { workspace = true, optional = true }
 sails-idl-meta.workspace = true
-sails-macros = { workspace = true, optional = true }
+sails-macros.workspace = true
 sails-reflect-hash.workspace = true
 sails-type-registry = { workspace = true, features = ["derive", "gprimitives"] }
 spin.workspace = true
@@ -60,10 +60,10 @@ ethexe = [
     "gsys/ethexe",
     "dep:alloy-primitives",
     "dep:alloy-sol-types",
-    "sails-macros?/ethexe",
+    "sails-macros/ethexe",
 ]
 gclient = ["dep:gclient", "dep:tokio-stream"]
-gstd = ["dep:gstd", "dep:gear-core", "dep:sails-macros"]
+gstd = ["dep:gstd", "dep:gear-core"]
 gtest = ["std", "dep:gtest", "dep:log", "dep:tokio-stream"]
 idl-gen = ["dep:sails-idl-gen"]
 client-builder = ["std", "idl-gen", "idl-embed", "dep:sails-client-gen-v2", "dep:convert_case"]

--- a/rs/client-gen-v2/src/events_generator.rs
+++ b/rs/client-gen-v2/src/events_generator.rs
@@ -32,9 +32,8 @@ impl<'ast> Visitor<'ast> for EventsModuleGenerator<'ast> {
             #[cfg(not(target_arch = "wasm32"))]
             pub mod events $("{")
                 use super::*;
-                #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-                #[codec(crate = $(self.sails_path)::scale_codec)]
-                #[reflect_hash(crate = $(self.sails_path))]
+                #[$(self.sails_path)::sails_type(crate = $(self.sails_path))]
+                #[derive(PartialEq, Debug)]
                 pub enum $events_name $("{")
         };
 

--- a/rs/client-gen-v2/src/lib.rs
+++ b/rs/client-gen-v2/src/lib.rs
@@ -67,7 +67,7 @@ impl<'ast, S> ClientGenerator<'ast, S> {
         }
     }
 
-    /// Derive only nessessary [`parity_scale_codec::Encode`], [`parity_scale_codec::Decode`], [`scale_info::TypeInfo`] and [`sails_reflect_hash::ReflectHash`] traits for the generated types
+    /// Derive only nessessary [`parity_scale_codec::Encode`], [`parity_scale_codec::Decode`], [`type_info::TypeInfo`] and [`sails_reflect_hash::ReflectHash`] traits for the generated types
     ///
     /// By default, types additionally derive [`PartialEq`], [`Clone`] and [`Debug`]
     pub fn with_no_derive_traits(self) -> Self {

--- a/rs/client-gen-v2/src/type_generators.rs
+++ b/rs/client-gen-v2/src/type_generators.rs
@@ -7,18 +7,14 @@ use crate::helpers::generate_doc_comments;
 pub(crate) struct TopLevelTypeGenerator<'ast> {
     type_name: &'ast str,
     sails_path: &'ast str,
-    derive_traits: &'ast str,
+    derive_traits: Option<&'ast str>,
     type_params_tokens: Tokens,
     tokens: Tokens,
 }
 
 impl<'ast> TopLevelTypeGenerator<'ast> {
     pub(crate) fn new(type_name: &'ast str, sails_path: &'ast str, no_derive_traits: bool) -> Self {
-        let derive_traits = if no_derive_traits {
-            "Encode, Decode, TypeInfo, ReflectHash"
-        } else {
-            "PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash"
-        };
+        let derive_traits = (!no_derive_traits).then_some("PartialEq, Clone, Debug");
         Self {
             type_name,
             sails_path,
@@ -88,7 +84,7 @@ impl<'ast> Visitor<'ast> for TopLevelTypeGenerator<'ast> {
 struct StructDefGenerator<'a> {
     type_name: &'a str,
     sails_path: &'a str,
-    derive_traits: &'a str,
+    derive_traits: Option<&'a str>,
     type_params_tokens: Tokens,
     is_tuple_struct: bool,
     tokens: Tokens,
@@ -98,7 +94,7 @@ impl<'a> StructDefGenerator<'a> {
     fn new(
         type_name: &'a str,
         sails_path: &'a str,
-        derive_traits: &'a str,
+        derive_traits: Option<&'a str>,
         type_params_tokens: Tokens,
     ) -> Self {
         Self {
@@ -116,10 +112,10 @@ impl<'a> StructDefGenerator<'a> {
         let postfix = if self.is_tuple_struct { ");" } else { "}" };
         quote! {
             $['\r']
-            #[derive($(self.derive_traits))]
-            #[codec(crate = $(self.sails_path)::scale_codec)]
-            #[type_info(crate = $(self.sails_path)::type_info)]
-            #[reflect_hash(crate = $(self.sails_path))]
+            #[$(self.sails_path)::sails_type(crate = $(self.sails_path))]
+            $(if let Some(traits) = self.derive_traits {
+                #[derive($traits)]
+            })
             pub struct $(self.type_name) $(self.type_params_tokens) $prefix $(self.tokens) $postfix
         }
     }
@@ -152,7 +148,7 @@ impl<'ast> Visitor<'ast> for StructDefGenerator<'ast> {
 struct EnumDefGenerator<'a> {
     type_name: &'a str,
     sails_path: &'a str,
-    derive_traits: &'a str,
+    derive_traits: Option<&'a str>,
     type_params_tokens: Tokens,
     tokens: Tokens,
 }
@@ -161,7 +157,7 @@ impl<'a> EnumDefGenerator<'a> {
     pub(crate) fn new(
         type_name: &'a str,
         sails_path: &'a str,
-        derive_traits: &'a str,
+        derive_traits: Option<&'a str>,
         type_params_tokens: Tokens,
     ) -> Self {
         Self {
@@ -176,10 +172,10 @@ impl<'a> EnumDefGenerator<'a> {
     pub(crate) fn finalize(self) -> Tokens {
         quote!(
             $['\r']
-            #[derive($(self.derive_traits))]
-            #[codec(crate = $(self.sails_path)::scale_codec)]
-            #[type_info(crate = $(self.sails_path)::type_info)]
-            #[reflect_hash(crate = $(self.sails_path))]
+            #[$(self.sails_path)::sails_type(crate = $(self.sails_path))]
+            $(if let Some(traits) = self.derive_traits {
+                #[derive($traits)]
+            })
             pub enum $(self.type_name) $(self.type_params_tokens) { $(self.tokens) }
         )
     }

--- a/rs/client-gen-v2/tests/snapshots/generator__aliases_works.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__aliases_works.snap
@@ -12,10 +12,8 @@ use sails_rs::{client::*, collections::*, prelude::*};
 pub mod aliases {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct MyStruct {
         pub f: u32,
     }

--- a/rs/client-gen-v2/tests/snapshots/generator__basic_works.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__basic_works.snap
@@ -12,19 +12,15 @@ use sails_rs::{client::*, collections::*, prelude::*};
 pub mod basic {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct MyParam {
         pub f1: u32,
         pub f2: Vec<String>,
         pub f3: Option<(u8, u32)>,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum MyParam2 {
         Variant1,
         Variant2(u32),

--- a/rs/client-gen-v2/tests/snapshots/generator__complex_type_generation_works.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__complex_type_generation_works.snap
@@ -72,28 +72,22 @@ pub mod io {
 pub mod my_complex_service {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ServiceLocalConfig {
         pub enabled: bool,
         pub retry_count: NonZeroU8,
         pub actor_list: Vec<ActorId>,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ServiceStatus {
         Active(ServiceLocalConfig),
         Paused,
         Error(ErrorType),
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ProgramGlobalInfo {
         pub id: ActorId,
         pub config_version: u32,
@@ -104,55 +98,41 @@ pub mod my_complex_service {
         pub non_zero_id: NonZeroU16,
         pub h256_hash: H256,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ProgramScopedData {
         pub name: String,
         pub value: U256,
         pub sub_id: u32,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ErrorType {
         InvalidInput,
         NotFound(String),
         AccessDenied { id: ActorId, reason: String },
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct GenericData<T, U> {
         pub value_t: T,
         pub value_u: U,
         pub description: String,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum GenericResult<V> {
         Success(V),
         Failure(ErrorType),
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct NonZeroU8(pub u8);
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct NonZeroU16(pub u16);
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct NonZeroU32(pub u32);
 
     pub trait MyComplexService {
@@ -267,10 +247,8 @@ pub mod my_complex_service {
 pub mod another_service {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ErrorType {
         InvalidInput,
         NotFound(String),

--- a/rs/client-gen-v2/tests/snapshots/generator__events_works.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__events_works.snap
@@ -12,10 +12,8 @@ use sails_rs::{client::*, collections::*, prelude::*};
 pub mod service_with_events {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct MyParam {
         pub f1: U256,
         pub f2: Vec<u8>,
@@ -59,9 +57,8 @@ pub mod service_with_events {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = sails_rs::scale_codec)]
-        #[reflect_hash(crate = sails_rs)]
+        #[sails_rs::sails_type(crate = sails_rs)]
+        #[derive(PartialEq, Debug)]
         pub enum ServiceWithEventsEvents {
             #[codec(index = 0)]
             One(u64),

--- a/rs/client-gen-v2/tests/snapshots/generator__external_types.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__external_types.snap
@@ -11,10 +11,7 @@ use my_crate::sails::{client::*, collections::*, prelude::*};
 pub mod service {
     use super::*;
 
-    #[derive(Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
     pub enum MyParam2 {
         Variant1,
         Variant2(u32),

--- a/rs/client-gen-v2/tests/snapshots/generator__full_with_sails_path.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__full_with_sails_path.snap
@@ -156,19 +156,15 @@ pub mod io {
     my_crate::sails::io_struct_impl!(Default () -> (), 0);
     my_crate::sails::io_struct_impl!(WithOwner (owner: ActorId, initial_config: super::ProgramConfig) -> (), 1);
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-#[codec(crate = my_crate::sails::scale_codec)]
-#[type_info(crate = my_crate::sails::type_info)]
-#[reflect_hash(crate = my_crate::sails)]
+#[my_crate::sails::sails_type(crate = my_crate::sails)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct ProgramConfig {
     pub initial_value: u32,
     pub admin: ActorId,
     pub is_active: bool,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-#[codec(crate = my_crate::sails::scale_codec)]
-#[type_info(crate = my_crate::sails::type_info)]
-#[reflect_hash(crate = my_crate::sails)]
+#[my_crate::sails::sails_type(crate = my_crate::sails)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum ProgramError {
     InvalidOwner,
     ConfigError(String),
@@ -177,43 +173,33 @@ pub enum ProgramError {
 pub mod canvas {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct Point<T> {
         pub x: T,
         pub y: T,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct Color {
         pub color: [u8; 4],
         pub space: ColorSpace,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ColorSpace {
         RGB,
         HSV,
         CMYK,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum PointStatus {
         Colored { author: ActorId, color: Color },
         Dead,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ColorError {
         InvalidSource,
         DeadPoint,
@@ -319,9 +305,8 @@ pub mod canvas {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = my_crate::sails::scale_codec)]
-        #[reflect_hash(crate = my_crate::sails)]
+        #[my_crate::sails::sails_type(crate = my_crate::sails)]
+        #[derive(PartialEq, Debug)]
         pub enum CanvasEvents {
             #[codec(index = 0)]
             E1,
@@ -446,9 +431,8 @@ pub mod counter {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = my_crate::sails::scale_codec)]
-        #[reflect_hash(crate = my_crate::sails)]
+        #[my_crate::sails::sails_type(crate = my_crate::sails)]
+        #[derive(PartialEq, Debug)]
         pub enum CounterEvents {
             /// Emitted when a new value is added to the counter
             #[codec(index = 0)]
@@ -540,9 +524,8 @@ pub mod dog {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = my_crate::sails::scale_codec)]
-        #[reflect_hash(crate = my_crate::sails)]
+        #[my_crate::sails::sails_type(crate = my_crate::sails)]
+        #[derive(PartialEq, Debug)]
         pub enum DogEvents {
             #[codec(index = 0)]
             Barked,
@@ -582,10 +565,8 @@ pub mod dog {
 pub mod references {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ReferenceCount(pub u32);
 
     pub trait References {
@@ -671,19 +652,15 @@ pub mod references {
 pub mod this_that {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct DoThatParam {
         pub p1: u32,
         pub p2: ActorId,
         pub p3: ManyVariants,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ManyVariants {
         One,
         Two(u32),
@@ -692,10 +669,8 @@ pub mod this_that {
         Five(String, H256),
         Six((u32,)),
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ManyVariantsReply {
         One,
         Two,
@@ -704,10 +679,8 @@ pub mod this_that {
         Five,
         Six,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct TupleStruct(pub bool);
 
     pub trait ThisThat {
@@ -813,9 +786,8 @@ pub mod value_fee {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = my_crate::sails::scale_codec)]
-        #[reflect_hash(crate = my_crate::sails)]
+        #[my_crate::sails::sails_type(crate = my_crate::sails)]
+        #[derive(PartialEq, Debug)]
         pub enum ValueFeeEvents {
             #[codec(index = 0)]
             Withheld(u128),
@@ -852,10 +824,8 @@ pub mod value_fee {
 pub mod pausable {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct PausedError();
 
     pub trait Pausable {
@@ -892,9 +862,8 @@ pub mod pausable {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = my_crate::sails::scale_codec)]
-        #[reflect_hash(crate = my_crate::sails)]
+        #[my_crate::sails::sails_type(crate = my_crate::sails)]
+        #[derive(PartialEq, Debug)]
         pub enum PausableEvents {
             #[codec(index = 0)]
             Paused,
@@ -998,10 +967,8 @@ pub mod tippable {
 pub mod non_zero_params {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct MyParam {
         pub f1: U256,
         pub f2: Vec<u8>,
@@ -1046,10 +1013,8 @@ pub mod non_zero_params {
 pub mod service_with_events {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct MyParam {
         pub f1: U256,
         pub f2: Vec<u8>,
@@ -1093,9 +1058,8 @@ pub mod service_with_events {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode, ReflectHash)]
-        #[codec(crate = my_crate::sails::scale_codec)]
-        #[reflect_hash(crate = my_crate::sails)]
+        #[my_crate::sails::sails_type(crate = my_crate::sails)]
+        #[derive(PartialEq, Debug)]
         pub enum ServiceWithEventsEvents {
             #[codec(index = 0)]
             Event1(u32),
@@ -1135,19 +1099,15 @@ pub mod service_with_events {
 pub mod basic {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct MyParam {
         pub f1: u32,
         pub f2: Vec<String>,
         pub f3: Option<(u8, u32)>,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum MyParam2 {
         Variant1,
         Variant2(u32),
@@ -1203,10 +1163,8 @@ pub mod basic {
 pub mod another_service {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ProgramError {
         InvalidOwner,
         ConfigError(String),
@@ -1253,10 +1211,8 @@ pub mod another_service {
 pub mod my_complex_service {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ProgramGlobalInfo {
         pub id: ActorId,
         pub config_version: u32,
@@ -1267,63 +1223,49 @@ pub mod my_complex_service {
         pub non_zero_id: u16,
         pub h256_hash: H256,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ProgramScopedData {
         pub name: String,
         pub value: U256,
         pub sub_id: u32,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ErrorType {
         InvalidInput,
         NotFound(String),
         AccessDenied { id: ActorId, reason: String },
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct GenericData<T, U> {
         pub value_t: T,
         pub value_u: U,
         pub description: String,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum GenericResult<V> {
         Success(V),
         Failure(ProgramError),
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ServiceLocalConfig {
         pub enabled: bool,
         pub retry_count: u8,
         pub actor_list: Vec<ActorId>,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ServiceStatus {
         Active(ServiceLocalConfig),
         Paused,
         Error(ProgramError),
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = my_crate::sails::scale_codec)]
-    #[type_info(crate = my_crate::sails::type_info)]
-    #[reflect_hash(crate = my_crate::sails)]
+    #[my_crate::sails::sails_type(crate = my_crate::sails)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum ProgramError {
         InvalidOwner,
         ConfigError(String),

--- a/rs/client-gen-v2/tests/snapshots/generator__multiple_services.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__multiple_services.snap
@@ -12,10 +12,8 @@ use sails_rs::{client::*, collections::*, prelude::*};
 pub mod multiple {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct MyParam {
         pub value: u32,
     }

--- a/rs/client-gen-v2/tests/snapshots/generator__rmrk_works.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__rmrk_works.snap
@@ -55,10 +55,8 @@ pub mod io {
 pub mod rmrk_catalog_service {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum Error {
         PartIdCantBeZero,
         BadConfig,
@@ -68,18 +66,14 @@ pub mod rmrk_catalog_service {
         WrongPartFormat,
         NotAllowedToCall,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub enum Part {
         Fixed(FixedPart),
         Slot(SlotPart),
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct FixedPart {
         /// An optional zIndex of base part layer.
         /// specifies the stack order of an element.
@@ -88,10 +82,8 @@ pub mod rmrk_catalog_service {
         /// The metadata URI of the part.
         pub metadata_uri: String,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct SlotPart {
         /// Array of whitelisted collections that can be equipped in the given slot. Used with slot parts only.
         pub equippable: Vec<ActorId>,

--- a/rs/client-gen-v2/tests/snapshots/generator__scope_resolution.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__scope_resolution.snap
@@ -45,17 +45,13 @@ pub mod io {
     use super::*;
     sails_rs::io_struct_impl!(Init () -> (), 0);
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_rs::sails_type(crate = sails_rs)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct CommonType {
     pub program_value: u32,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_rs::sails_type(crate = sails_rs)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct ProgramOnlyType {
     pub data: CommonType,
 }
@@ -63,24 +59,18 @@ pub struct ProgramOnlyType {
 pub mod my_service {
     use super::*;
 
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct CommonType {
         pub service_name: String,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ServiceCommonType {
         pub service_id: u64,
     }
-    #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo, ReflectHash)]
-    #[codec(crate = sails_rs::scale_codec)]
-    #[type_info(crate = sails_rs::type_info)]
-    #[reflect_hash(crate = sails_rs)]
+    #[sails_rs::sails_type(crate = sails_rs)]
+    #[derive(PartialEq, Clone, Debug)]
     pub struct ProgramOnlyType {
         pub data: CommonType,
     }

--- a/rs/client-gen/src/events_generator.rs
+++ b/rs/client-gen/src/events_generator.rs
@@ -36,8 +36,8 @@ impl<'ast> Visitor<'ast> for EventsModuleGenerator<'_> {
             #[cfg(not(target_arch = "wasm32"))]
             pub mod events $("{")
                 use super::*;
-                #[derive(PartialEq, Debug, Encode, Decode)]
-                #[codec(crate = $(self.sails_path)::scale_codec)]
+                #[$(self.sails_path)::sails_type(crate = $(self.sails_path), no_reflect_hash)]
+                #[derive(PartialEq, Debug)]
                 pub enum $events_name $("{")
         };
 

--- a/rs/client-gen/src/lib.rs
+++ b/rs/client-gen/src/lib.rs
@@ -68,7 +68,7 @@ impl<'a, S> ClientGenerator<'a, S> {
         }
     }
 
-    /// Derive only nessessary [`parity_scale_codec::Encode`], [`parity_scale_codec::Decode`] and [`type_info::TypeInfo`] traits for the generated types
+    /// Derive only nessessary [`parity_scale_codec::Encode`], [`parity_scale_codec::Decode`] and [`scale_info::TypeInfo`] traits for the generated types
     ///
     /// By default, types additionally derive [`PartialEq`], [`Clone`] and [`Debug`]
     pub fn with_no_derive_traits(self) -> Self {

--- a/rs/client-gen/src/lib.rs
+++ b/rs/client-gen/src/lib.rs
@@ -68,7 +68,7 @@ impl<'a, S> ClientGenerator<'a, S> {
         }
     }
 
-    /// Derive only nessessary [`parity_scale_codec::Encode`], [`parity_scale_codec::Decode`] and [`scale_info::TypeInfo`] traits for the generated types
+    /// Derive only necessary [parity_scale_codec::Encode], [parity_scale_codec::Decode] and [type_info::TypeInfo] traits for the generated types
     ///
     /// By default, types additionally derive [`PartialEq`], [`Clone`] and [`Debug`]
     pub fn with_no_derive_traits(self) -> Self {

--- a/rs/client-gen/src/type_generators.rs
+++ b/rs/client-gen/src/type_generators.rs
@@ -20,17 +20,13 @@ pub(crate) fn generate_type_decl_with_path(type_decl: &TypeDecl, path: String) -
 pub(crate) struct TopLevelTypeGenerator<'a> {
     type_name: &'a str,
     sails_path: &'a str,
-    derive_traits: &'a str,
+    derive_traits: Option<&'a str>,
     tokens: Tokens,
 }
 
 impl<'a> TopLevelTypeGenerator<'a> {
     pub(crate) fn new(type_name: &'a str, sails_path: &'a str, no_derive_traits: bool) -> Self {
-        let derive_traits = if no_derive_traits {
-            "Encode, Decode, TypeInfo"
-        } else {
-            "PartialEq, Clone, Debug, Encode, Decode, TypeInfo"
-        };
+        let derive_traits = (!no_derive_traits).then_some("PartialEq, Clone, Debug");
         Self {
             type_name,
             sails_path,
@@ -73,13 +69,13 @@ impl<'ast> Visitor<'ast> for TopLevelTypeGenerator<'_> {
 struct StructDefGenerator<'a> {
     type_name: &'a str,
     sails_path: &'a str,
-    derive_traits: &'a str,
+    derive_traits: Option<&'a str>,
     is_tuple_struct: bool,
     tokens: Tokens,
 }
 
 impl<'a> StructDefGenerator<'a> {
-    fn new(type_name: &'a str, sails_path: &'a str, derive_traits: &'a str) -> Self {
+    fn new(type_name: &'a str, sails_path: &'a str, derive_traits: Option<&'a str>) -> Self {
         Self {
             type_name,
             sails_path,
@@ -94,9 +90,10 @@ impl<'a> StructDefGenerator<'a> {
         let postfix = if self.is_tuple_struct { ");" } else { "}" };
         quote! {
             $['\r']
-            #[derive($(self.derive_traits))]
-            #[codec(crate = $(self.sails_path)::scale_codec)]
-            #[type_info(crate = $(self.sails_path)::type_info)]
+            #[$(self.sails_path)::sails_type(crate = $(self.sails_path), no_reflect_hash)]
+            $(if let Some(traits) = self.derive_traits {
+                #[derive($traits)]
+            })
             pub struct $(self.type_name) $prefix $(self.tokens) $postfix
         }
     }
@@ -138,12 +135,16 @@ impl<'ast> Visitor<'ast> for StructDefGenerator<'ast> {
 struct EnumDefGenerator<'a> {
     type_name: &'a str,
     sails_path: &'a str,
-    derive_traits: &'a str,
+    derive_traits: Option<&'a str>,
     tokens: Tokens,
 }
 
 impl<'a> EnumDefGenerator<'a> {
-    pub(crate) fn new(type_name: &'a str, sails_path: &'a str, derive_traits: &'a str) -> Self {
+    pub(crate) fn new(
+        type_name: &'a str,
+        sails_path: &'a str,
+        derive_traits: Option<&'a str>,
+    ) -> Self {
         Self {
             type_name,
             sails_path,
@@ -155,9 +156,10 @@ impl<'a> EnumDefGenerator<'a> {
     pub(crate) fn finalize(self) -> Tokens {
         quote!(
             $['\r']
-            #[derive($(self.derive_traits))]
-            #[codec(crate = $(self.sails_path)::scale_codec)]
-            #[type_info(crate = $(self.sails_path)::type_info)]
+            #[$(self.sails_path)::sails_type(crate = $(self.sails_path), no_reflect_hash)]
+            $(if let Some(traits) = self.derive_traits {
+                #[derive($traits)]
+            })
             pub enum $(self.type_name) { $(self.tokens) }
         )
     }

--- a/rs/client-gen/tests/demo_gtest.rs
+++ b/rs/client-gen/tests/demo_gtest.rs
@@ -1,5 +1,6 @@
 #[allow(dead_code, unexpected_cfgs)]
 mod demo_client {
+    // cargo run -p sails-cli -- sails client-rs --v1 rs\client-gen\tests\idls\demo.idl rs\client-gen\tests\generated\demo_client_v1.rs
     include!("generated/demo_client_v1.rs");
 }
 

--- a/rs/client-gen/tests/generated/demo_client_v1.rs
+++ b/rs/client-gen/tests/generated/demo_client_v1.rs
@@ -173,8 +173,8 @@ pub mod counter {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode)]
-        #[codec(crate = sails_rs::scale_codec)]
+        #[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+        #[derive(PartialEq, Debug)]
         pub enum CounterEvents {
             /// Emitted when a new value is added to the counter
             Added(u32),
@@ -242,8 +242,8 @@ pub mod dog {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode)]
-        #[codec(crate = sails_rs::scale_codec)]
+        #[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+        #[derive(PartialEq, Debug)]
         pub enum DogEvents {
             Barked,
             Walked { from: (i32, i32), to: (i32, i32) },
@@ -429,8 +429,8 @@ pub mod value_fee {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode)]
-        #[codec(crate = sails_rs::scale_codec)]
+        #[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+        #[derive(PartialEq, Debug)]
         pub enum ValueFeeEvents {
             Withheld(u128),
         }
@@ -491,21 +491,18 @@ pub mod chaos {
         sails_rs::io_struct_impl_v1!(TimeoutWait () -> ());
     }
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct ReferenceCount(pub u32);
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct DoThatParam {
     pub p1: NonZeroU32,
     pub p2: ActorId,
     pub p3: ManyVariants,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum ManyVariants {
     One,
     Two(u32),
@@ -514,9 +511,8 @@ pub enum ManyVariants {
     Five((String, H256)),
     Six((u32,)),
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum ManyVariantsReply {
     One,
     Two,
@@ -525,7 +521,6 @@ pub enum ManyVariantsReply {
     Five,
     Six,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct TupleStruct(pub bool);

--- a/rs/client-gen/tests/snapshots/generator__basic_works.snap
+++ b/rs/client-gen/tests/snapshots/generator__basic_works.snap
@@ -68,17 +68,15 @@ pub mod basic {
         sails_rs::io_struct_impl_v1!(DoThat (p1: (u8,u32,)) -> u8);
     }
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct MyParam {
     pub f1: u32,
     pub f2: Vec<String>,
     pub f3: Option<(u8, u32)>,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum MyParam2 {
     Variant1,
     Variant2(u32),

--- a/rs/client-gen/tests/snapshots/generator__demo_works.snap
+++ b/rs/client-gen/tests/snapshots/generator__demo_works.snap
@@ -177,8 +177,8 @@ pub mod counter {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode)]
-        #[codec(crate = sails_rs::scale_codec)]
+        #[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+        #[derive(PartialEq, Debug)]
         pub enum CounterEvents {
             /// Emitted when a new value is added to the counter
             Added(u32),
@@ -246,8 +246,8 @@ pub mod dog {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode)]
-        #[codec(crate = sails_rs::scale_codec)]
+        #[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+        #[derive(PartialEq, Debug)]
         pub enum DogEvents {
             Barked,
             Walked { from: (i32, i32), to: (i32, i32) },
@@ -433,8 +433,8 @@ pub mod value_fee {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode)]
-        #[codec(crate = sails_rs::scale_codec)]
+        #[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+        #[derive(PartialEq, Debug)]
         pub enum ValueFeeEvents {
             Withheld(u128),
         }
@@ -495,21 +495,18 @@ pub mod chaos {
         sails_rs::io_struct_impl_v1!(TimeoutWait () -> ());
     }
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct ReferenceCount(pub u32);
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct DoThatParam {
     pub p1: NonZeroU32,
     pub p2: ActorId,
     pub p3: ManyVariants,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum ManyVariants {
     One,
     Two(u32),
@@ -518,9 +515,8 @@ pub enum ManyVariants {
     Five((String, H256)),
     Six((u32,)),
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum ManyVariantsReply {
     One,
     Two,
@@ -529,9 +525,8 @@ pub enum ManyVariantsReply {
     Five,
     Six,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct TupleStruct(pub bool);
 
 #[cfg(feature = "with_mocks")]

--- a/rs/client-gen/tests/snapshots/generator__events_works.snap
+++ b/rs/client-gen/tests/snapshots/generator__events_works.snap
@@ -70,8 +70,8 @@ pub mod service_with_events {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode)]
-        #[codec(crate = sails_rs::scale_codec)]
+        #[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+        #[derive(PartialEq, Debug)]
         pub enum ServiceWithEventsEvents {
             One(u64),
             Two { id: u8, reference: u64 },
@@ -97,9 +97,8 @@ pub mod service_with_events {
         }
     }
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct MyParam {
     pub f1: NonZeroU256,
     pub f2: Vec<NonZeroU8>,

--- a/rs/client-gen/tests/snapshots/generator__external_types.snap
+++ b/rs/client-gen/tests/snapshots/generator__external_types.snap
@@ -80,9 +80,7 @@ pub mod service {
         my_crate::sails::io_struct_impl_v1!(DoThat (p1: (u8,u32,)) -> u8);
     }
 }
-#[derive(Encode, Decode, TypeInfo)]
-#[codec(crate = my_crate::sails::scale_codec)]
-#[type_info(crate = my_crate::sails::type_info)]
+#[my_crate::sails::sails_type(crate = my_crate::sails, no_reflect_hash)]
 pub enum MyParam2 {
     Variant1,
     Variant2(u32),

--- a/rs/client-gen/tests/snapshots/generator__full.snap
+++ b/rs/client-gen/tests/snapshots/generator__full.snap
@@ -115,8 +115,8 @@ pub mod service {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode)]
-        #[codec(crate = sails_rs::scale_codec)]
+        #[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+        #[derive(PartialEq, Debug)]
         pub enum ServiceEvents {
             /// `This` Done
             ThisDone(u32),
@@ -145,17 +145,15 @@ pub mod service {
     }
 }
 /// ThisThatSvcAppTupleStruct docs
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct ThisThatSvcAppTupleStruct(
     /// field `bool`
     pub bool,
 );
 /// ThisThatSvcAppDoThatParam docs
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct ThisThatSvcAppDoThatParam {
     /// field `query`
     pub query: u32,
@@ -165,9 +163,8 @@ pub struct ThisThatSvcAppDoThatParam {
     pub p3: ThisThatSvcAppManyVariants,
 }
 /// ThisThatSvcAppManyVariants docs
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum ThisThatSvcAppManyVariants {
     /// variant `One`
     One,
@@ -181,9 +178,8 @@ pub enum ThisThatSvcAppManyVariants {
     Five((String, u32)),
     Six((u32,)),
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum T {
     One,
 }

--- a/rs/client-gen/tests/snapshots/generator__full_with_sails_path.snap
+++ b/rs/client-gen/tests/snapshots/generator__full_with_sails_path.snap
@@ -193,8 +193,8 @@ pub mod counter {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod events {
         use super::*;
-        #[derive(PartialEq, Debug, Encode, Decode)]
-        #[codec(crate = my_crate::sails::scale_codec)]
+        #[my_crate::sails::sails_type(crate = my_crate::sails, no_reflect_hash)]
+        #[derive(PartialEq, Debug)]
         pub enum CounterEvents {
             /// Emitted when a new value is added to the counter
             Added(u32),
@@ -221,21 +221,18 @@ pub mod counter {
         }
     }
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = my_crate::sails::scale_codec)]
-#[type_info(crate = my_crate::sails::type_info)]
+#[my_crate::sails::sails_type(crate = my_crate::sails, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct ThisThatSvcAppTupleStruct(pub bool);
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = my_crate::sails::scale_codec)]
-#[type_info(crate = my_crate::sails::type_info)]
+#[my_crate::sails::sails_type(crate = my_crate::sails, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct ThisThatSvcAppDoThatParam {
     pub p1: u32,
     pub p2: String,
     pub p3: ThisThatSvcAppManyVariants,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = my_crate::sails::scale_codec)]
-#[type_info(crate = my_crate::sails::type_info)]
+#[my_crate::sails::sails_type(crate = my_crate::sails, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum ThisThatSvcAppManyVariants {
     One,
     Two(u32),
@@ -244,9 +241,8 @@ pub enum ThisThatSvcAppManyVariants {
     Five((String, u32)),
     Six((u32,)),
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = my_crate::sails::scale_codec)]
-#[type_info(crate = my_crate::sails::type_info)]
+#[my_crate::sails::sails_type(crate = my_crate::sails, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum T {
     One,
 }

--- a/rs/client-gen/tests/snapshots/generator__nonzero_works.snap
+++ b/rs/client-gen/tests/snapshots/generator__nonzero_works.snap
@@ -67,9 +67,8 @@ pub mod non_zero_params {
         sails_rs::io_struct_impl_v1!(DoThis (p1: NonZeroU256, p2: super::MyParam) -> NonZeroU64);
     }
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct MyParam {
     pub f1: NonZeroU256,
     pub f2: Vec<NonZeroU8>,

--- a/rs/client-gen/tests/snapshots/generator__rmrk_works.snap
+++ b/rs/client-gen/tests/snapshots/generator__rmrk_works.snap
@@ -161,9 +161,8 @@ pub mod rmrk_catalog {
         sails_rs::io_struct_impl_v1!(Part (part_id: u32) -> Option<super::Part>);
     }
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum Error {
     PartIdCantBeZero,
     BadConfig,
@@ -173,16 +172,14 @@ pub enum Error {
     WrongPartFormat,
     NotAllowedToCall,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum Part {
     Fixed(FixedPart),
     Slot(SlotPart),
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct FixedPart {
     /// An optional zIndex of base part layer.
     /// specifies the stack order of an element.
@@ -191,9 +188,8 @@ pub struct FixedPart {
     /// The metadata URI of the part.
     pub metadata_uri: String,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[type_info(crate = sails_rs::type_info)]
+#[sails_rs::sails_type(crate = sails_rs, no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct SlotPart {
     /// Array of whitelisted collections that can be equipped in the given slot. Used with slot parts only.
     pub equippable: Vec<ActorId>,

--- a/rs/ethexe/ethapp_with_events/src/lib.rs
+++ b/rs/ethexe/ethapp_with_events/src/lib.rs
@@ -5,9 +5,8 @@ use sails_rs::prelude::*;
 
 /// Service Events
 #[sails_rs::event]
-#[derive(Clone, Debug, PartialEq, Encode, TypeInfo, ReflectHash)]
-#[codec(crate = sails_rs::scale_codec)]
-#[reflect_hash(crate = sails_rs)]
+#[sails_type]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Events {
     DoThisEvent {
         /// Some u32 value

--- a/rs/macros/core/src/lib.rs
+++ b/rs/macros/core/src/lib.rs
@@ -21,11 +21,13 @@
 pub use event::{derive_sails_event, event};
 pub use export::export;
 pub use program::{__gprogram_internal, gprogram};
+pub use sails_type::sails_type;
 pub use service::{__gservice_internal, gservice};
 
 mod event;
 mod export;
 mod program;
 mod sails_paths;
+mod sails_type;
 mod service;
 mod shared;

--- a/rs/macros/core/src/sails_type/args.rs
+++ b/rs/macros/core/src/sails_type/args.rs
@@ -1,0 +1,62 @@
+use syn::{
+    Path, Token,
+    parse::{Parse, ParseBuffer},
+};
+
+#[derive(Debug, Default, PartialEq)]
+pub(super) struct SailsTypeArgs {
+    pub path: Option<Path>,
+    pub no_reflect_hash: bool,
+}
+
+impl Parse for SailsTypeArgs {
+    fn parse(input: &ParseBuffer) -> syn::Result<Self> {
+        let mut out = SailsTypeArgs::default();
+        if input.is_empty() {
+            return Ok(out);
+        }
+
+        loop {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(Token![crate]) {
+                input.parse::<Token![crate]>()?;
+                input.parse::<Token![=]>()?;
+                let path = input.parse::<Path>()?;
+                if out.path.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        &path,
+                        "`crate` argument specified more than once",
+                    ));
+                }
+                out.path = Some(path);
+            } else if lookahead.peek(syn::Ident) {
+                let ident: syn::Ident = input.parse()?;
+                if ident == "no_reflect_hash" {
+                    if out.no_reflect_hash {
+                        return Err(syn::Error::new_spanned(
+                            &ident,
+                            "`no_reflect_hash` specified more than once",
+                        ));
+                    }
+                    out.no_reflect_hash = true;
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        &ident,
+                        format!(
+                            "unknown `sails_type` argument `{ident}` (expected `crate = <path>` or `no_reflect_hash`)"
+                        ),
+                    ));
+                }
+            } else {
+                return Err(lookahead.error());
+            }
+
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+
+        Ok(out)
+    }
+}

--- a/rs/macros/core/src/sails_type/mod.rs
+++ b/rs/macros/core/src/sails_type/mod.rs
@@ -1,0 +1,56 @@
+use crate::sails_paths::sails_path_or_default;
+use args::SailsTypeArgs;
+use proc_macro2::TokenStream;
+use proc_macro_error::abort;
+use quote::quote;
+use syn::{Item, Path};
+
+mod args;
+
+pub fn sails_type(attrs: TokenStream, item: TokenStream) -> TokenStream {
+    let args: SailsTypeArgs = syn::parse2(attrs).unwrap_or_else(|err| {
+        abort!(err.span(), "invalid `sails_type` arguments: {}", err)
+    });
+
+    let parsed: Item = syn::parse2(item).unwrap_or_else(|err| {
+        abort!(
+            err.span(),
+            "`sails_type` can only be applied to structs or enums: {}",
+            err
+        )
+    });
+
+    match &parsed {
+        Item::Struct(_) | Item::Enum(_) => {}
+        other => abort!(other, "`sails_type` can only be applied to structs or enums"),
+    }
+
+    let sails_path: Path = sails_path_or_default(args.path);
+    let scale_codec = quote! { #sails_path::scale_codec };
+    let type_info = quote! { #sails_path::type_info };
+
+    let (derive_list, reflect_hash_attr) = if args.no_reflect_hash {
+        (
+            quote! { #scale_codec::Encode, #scale_codec::Decode, #type_info::TypeInfo },
+            quote! {},
+        )
+    } else {
+        (
+            quote! {
+                #scale_codec::Encode,
+                #scale_codec::Decode,
+                #type_info::TypeInfo,
+                #sails_path::ReflectHash
+            },
+            quote! { #[reflect_hash(crate = #sails_path)] },
+        )
+    };
+
+    quote! {
+        #[derive(#derive_list)]
+        #[codec(crate = #scale_codec)]
+        #[type_info(crate = #type_info)]
+        #reflect_hash_attr
+        #parsed
+    }
+}

--- a/rs/macros/core/src/sails_type/mod.rs
+++ b/rs/macros/core/src/sails_type/mod.rs
@@ -1,16 +1,15 @@
 use crate::sails_paths::sails_path_or_default;
 use args::SailsTypeArgs;
-use proc_macro2::TokenStream;
 use proc_macro_error::abort;
+use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Item, Path};
 
 mod args;
 
 pub fn sails_type(attrs: TokenStream, item: TokenStream) -> TokenStream {
-    let args: SailsTypeArgs = syn::parse2(attrs).unwrap_or_else(|err| {
-        abort!(err.span(), "invalid `sails_type` arguments: {}", err)
-    });
+    let args: SailsTypeArgs = syn::parse2(attrs)
+        .unwrap_or_else(|err| abort!(err.span(), "invalid `sails_type` arguments: {}", err));
 
     let parsed: Item = syn::parse2(item).unwrap_or_else(|err| {
         abort!(
@@ -22,7 +21,10 @@ pub fn sails_type(attrs: TokenStream, item: TokenStream) -> TokenStream {
 
     match &parsed {
         Item::Struct(_) | Item::Enum(_) => {}
-        other => abort!(other, "`sails_type` can only be applied to structs or enums"),
+        other => abort!(
+            other,
+            "`sails_type` can only be applied to structs or enums"
+        ),
     }
 
     let sails_path: Path = sails_path_or_default(args.path);

--- a/rs/macros/core/tests/sails_type.rs
+++ b/rs/macros/core/tests/sails_type.rs
@@ -1,0 +1,68 @@
+use quote::quote;
+use sails_macros_core::sails_type;
+
+fn format(tokens: proc_macro2::TokenStream) -> String {
+    let text = tokens.to_string();
+    prettyplease::unparse(&syn::parse_str(&text).expect("sails_type output must parse"))
+}
+
+#[test]
+fn struct_basic() {
+    let input = quote! {
+        pub struct MyType {
+            pub a: u32,
+            pub b: String,
+        }
+    };
+    let result = format(sails_type(quote!(), input));
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn enum_basic() {
+    let input = quote! {
+        pub enum MyEnum {
+            A,
+            B(u32),
+            C { x: String },
+        }
+    };
+    let result = format(sails_type(quote!(), input));
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn struct_with_generics() {
+    let input = quote! {
+        pub struct MyType<T: Clone> where T: core::fmt::Debug {
+            pub value: T,
+        }
+    };
+    let result = format(sails_type(quote!(), input));
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn custom_crate_path() {
+    let attrs = quote! { crate = sails_rename };
+    let input = quote! { pub struct MyType { pub a: u32 } };
+    let result = format(sails_type(attrs, input));
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn no_reflect_hash_flag() {
+    let attrs = quote! { no_reflect_hash };
+    let input = quote! { pub struct MyType { pub a: u32 } };
+    let result = format(sails_type(attrs, input));
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn custom_crate_path_and_no_reflect_hash() {
+    let attrs = quote! { crate = sails_rename, no_reflect_hash };
+    let input = quote! { pub struct MyType { pub a: u32 } };
+    let result = format(sails_type(attrs, input));
+    insta::assert_snapshot!(result);
+}
+

--- a/rs/macros/core/tests/sails_type.rs
+++ b/rs/macros/core/tests/sails_type.rs
@@ -65,4 +65,3 @@ fn custom_crate_path_and_no_reflect_hash() {
     let result = format(sails_type(attrs, input));
     insta::assert_snapshot!(result);
 }
-

--- a/rs/macros/core/tests/snapshots/sails_type__custom_crate_path.snap
+++ b/rs/macros/core/tests/snapshots/sails_type__custom_crate_path.snap
@@ -1,0 +1,16 @@
+---
+source: rs/macros/core/tests/sails_type.rs
+expression: result
+---
+#[derive(
+    sails_rename::scale_codec::Encode,
+    sails_rename::scale_codec::Decode,
+    sails_rename::type_info::TypeInfo,
+    sails_rename::ReflectHash
+)]
+#[codec(crate = sails_rename::scale_codec)]
+#[type_info(crate = sails_rename::type_info)]
+#[reflect_hash(crate = sails_rename)]
+pub struct MyType {
+    pub a: u32,
+}

--- a/rs/macros/core/tests/snapshots/sails_type__custom_crate_path_and_no_reflect_hash.snap
+++ b/rs/macros/core/tests/snapshots/sails_type__custom_crate_path_and_no_reflect_hash.snap
@@ -1,0 +1,14 @@
+---
+source: rs/macros/core/tests/sails_type.rs
+expression: result
+---
+#[derive(
+    sails_rename::scale_codec::Encode,
+    sails_rename::scale_codec::Decode,
+    sails_rename::type_info::TypeInfo
+)]
+#[codec(crate = sails_rename::scale_codec)]
+#[type_info(crate = sails_rename::type_info)]
+pub struct MyType {
+    pub a: u32,
+}

--- a/rs/macros/core/tests/snapshots/sails_type__enum_basic.snap
+++ b/rs/macros/core/tests/snapshots/sails_type__enum_basic.snap
@@ -1,0 +1,18 @@
+---
+source: rs/macros/core/tests/sails_type.rs
+expression: result
+---
+#[derive(
+    sails_rs::scale_codec::Encode,
+    sails_rs::scale_codec::Decode,
+    sails_rs::type_info::TypeInfo,
+    sails_rs::ReflectHash
+)]
+#[codec(crate = sails_rs::scale_codec)]
+#[type_info(crate = sails_rs::type_info)]
+#[reflect_hash(crate = sails_rs)]
+pub enum MyEnum {
+    A,
+    B(u32),
+    C { x: String },
+}

--- a/rs/macros/core/tests/snapshots/sails_type__no_reflect_hash_flag.snap
+++ b/rs/macros/core/tests/snapshots/sails_type__no_reflect_hash_flag.snap
@@ -1,0 +1,14 @@
+---
+source: rs/macros/core/tests/sails_type.rs
+expression: result
+---
+#[derive(
+    sails_rs::scale_codec::Encode,
+    sails_rs::scale_codec::Decode,
+    sails_rs::type_info::TypeInfo
+)]
+#[codec(crate = sails_rs::scale_codec)]
+#[type_info(crate = sails_rs::type_info)]
+pub struct MyType {
+    pub a: u32,
+}

--- a/rs/macros/core/tests/snapshots/sails_type__struct_basic.snap
+++ b/rs/macros/core/tests/snapshots/sails_type__struct_basic.snap
@@ -1,0 +1,17 @@
+---
+source: rs/macros/core/tests/sails_type.rs
+expression: result
+---
+#[derive(
+    sails_rs::scale_codec::Encode,
+    sails_rs::scale_codec::Decode,
+    sails_rs::type_info::TypeInfo,
+    sails_rs::ReflectHash
+)]
+#[codec(crate = sails_rs::scale_codec)]
+#[type_info(crate = sails_rs::type_info)]
+#[reflect_hash(crate = sails_rs)]
+pub struct MyType {
+    pub a: u32,
+    pub b: String,
+}

--- a/rs/macros/core/tests/snapshots/sails_type__struct_with_generics.snap
+++ b/rs/macros/core/tests/snapshots/sails_type__struct_with_generics.snap
@@ -1,0 +1,19 @@
+---
+source: rs/macros/core/tests/sails_type.rs
+expression: result
+---
+#[derive(
+    sails_rs::scale_codec::Encode,
+    sails_rs::scale_codec::Decode,
+    sails_rs::type_info::TypeInfo,
+    sails_rs::ReflectHash
+)]
+#[codec(crate = sails_rs::scale_codec)]
+#[type_info(crate = sails_rs::type_info)]
+#[reflect_hash(crate = sails_rs)]
+pub struct MyType<T: Clone>
+where
+    T: core::fmt::Debug,
+{
+    pub value: T,
+}

--- a/rs/macros/src/lib.rs
+++ b/rs/macros/src/lib.rs
@@ -203,3 +203,41 @@ pub fn export(args: TokenStream, impl_item_fn_tokens: TokenStream) -> TokenStrea
 pub fn event(args: TokenStream, input: TokenStream) -> TokenStream {
     sails_macros_core::event(args.into(), input.into()).into()
 }
+
+/// Derives the canonical Sails type bundle: `Encode`, `Decode`, `TypeInfo`,
+/// and `ReflectHash`, together with their `crate =` helper attributes routed
+/// to the `sails_rs` re-exports.
+///
+/// # Arguments
+///
+/// - `crate = <path>` — override the path to the `sails-rs` crate (defaults to
+///   `sails_rs`). Useful when `sails-rs` is re-exported from a parent crate.
+/// - `no_reflect_hash` — omit `ReflectHash` from the derive list and drop the
+///   `reflect_hash` helper attribute. Exists specifically for the IDL v1
+///   client generator, which predates `ReflectHash`.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use sails_rs::sails_type;
+///
+/// #[sails_type]
+/// #[derive(PartialEq, Clone, Debug)]
+/// pub struct MyType {
+///     pub a: u32,
+///     pub b: String,
+/// }
+///
+/// #[sails_type(crate = my_alias)]
+/// pub enum MyEnum { A, B }
+///
+/// #[sails_type(no_reflect_hash)]
+/// pub struct LegacyType { pub a: u32 }
+/// ```
+///
+/// Composes with `#[event]` in any order — the two macros are orthogonal.
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn sails_type(args: TokenStream, item: TokenStream) -> TokenStream {
+    sails_macros_core::sails_type(args.into(), item.into()).into()
+}

--- a/rs/macros/tests/sails_type_roundtrip/mod.rs
+++ b/rs/macros/tests/sails_type_roundtrip/mod.rs
@@ -1,0 +1,22 @@
+use sails_rs::prelude::*;
+
+#[sails_type]
+#[derive(PartialEq, Clone, Debug)]
+pub struct MyType {
+    pub a: u32,
+    pub b: String,
+}
+
+#[sails_type]
+#[derive(PartialEq, Clone, Debug)]
+pub enum MyEnum {
+    Unit,
+    Tuple(u32, String),
+    Named { x: u32 },
+}
+
+#[sails_type(no_reflect_hash)]
+#[derive(PartialEq, Clone, Debug)]
+pub struct LegacyType {
+    pub a: u32,
+}

--- a/rs/macros/tests/sails_type_tests.rs
+++ b/rs/macros/tests/sails_type_tests.rs
@@ -1,0 +1,34 @@
+#![cfg(not(feature = "ethexe"))]
+
+use sails_rs::{Decode, Encode};
+
+mod sails_type_roundtrip;
+
+use sails_type_roundtrip::{LegacyType, MyEnum, MyType};
+
+#[test]
+fn struct_round_trips() {
+    let value = MyType {
+        a: 42,
+        b: "hello".to_string(),
+    };
+    let bytes = value.encode();
+    let decoded = MyType::decode(&mut &bytes[..]).unwrap();
+    assert_eq!(value, decoded);
+}
+
+#[test]
+fn enum_round_trips() {
+    let value = MyEnum::Named { x: 7 };
+    let bytes = value.encode();
+    let decoded = MyEnum::decode(&mut &bytes[..]).unwrap();
+    assert_eq!(value, decoded);
+}
+
+#[test]
+fn legacy_type_round_trips() {
+    let value = LegacyType { a: 99 };
+    let bytes = value.encode();
+    let decoded = LegacyType::decode(&mut &bytes[..]).unwrap();
+    assert_eq!(value, decoded);
+}

--- a/rs/macros/tests/ui/sails_type_fails_on_trait.rs
+++ b/rs/macros/tests/ui/sails_type_fails_on_trait.rs
@@ -1,0 +1,6 @@
+use sails_rs::sails_type;
+
+#[sails_type]
+pub trait MyTrait {}
+
+fn main() {}

--- a/rs/macros/tests/ui/sails_type_fails_on_trait.stderr
+++ b/rs/macros/tests/ui/sails_type_fails_on_trait.stderr
@@ -1,0 +1,5 @@
+error: `sails_type` can only be applied to structs or enums
+ --> tests/ui/sails_type_fails_on_trait.rs:4:1
+  |
+4 | pub trait MyTrait {}
+  | ^^^^^^^^^^^^^^^^^^^^

--- a/rs/macros/tests/ui/sails_type_fails_unknown_arg.rs
+++ b/rs/macros/tests/ui/sails_type_fails_unknown_arg.rs
@@ -1,0 +1,6 @@
+use sails_rs::sails_type;
+
+#[sails_type(bogus)]
+pub struct S;
+
+fn main() {}

--- a/rs/macros/tests/ui/sails_type_fails_unknown_arg.stderr
+++ b/rs/macros/tests/ui/sails_type_fails_unknown_arg.stderr
@@ -1,0 +1,5 @@
+error: invalid `sails_type` arguments: unknown `sails_type` argument `bogus` (expected `crate = <path>` or `no_reflect_hash`)
+ --> tests/ui/sails_type_fails_unknown_arg.rs:3:14
+  |
+3 | #[sails_type(bogus)]
+  |              ^^^^^

--- a/rs/macros/tests/ui_error_tests.rs
+++ b/rs/macros/tests/ui_error_tests.rs
@@ -11,3 +11,9 @@ fn gprogram_fails() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/gprogram_fails*.rs");
 }
+
+#[test]
+fn sails_type_fails() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/sails_type_fails*.rs");
+}

--- a/rs/src/gstd/mod.rs
+++ b/rs/src/gstd/mod.rs
@@ -11,7 +11,7 @@ pub use gstd::{async_init, async_main, handle_reply_with_hook, message_loop};
 pub use gstd::{debug, exec, msg};
 use sails_idl_meta::{InterfaceId, MethodMeta};
 #[doc(hidden)]
-pub use sails_macros::{event, export, program, service};
+pub use sails_macros::{event, export, program, sails_type, service};
 pub use syscalls::Syscall;
 
 /// Maximum payload size for structured panic.

--- a/rs/src/gstd/mod.rs
+++ b/rs/src/gstd/mod.rs
@@ -11,7 +11,7 @@ pub use gstd::{async_init, async_main, handle_reply_with_hook, message_loop};
 pub use gstd::{debug, exec, msg};
 use sails_idl_meta::{InterfaceId, MethodMeta};
 #[doc(hidden)]
-pub use sails_macros::{event, export, program, sails_type, service};
+pub use sails_macros::{event, export, program, service};
 pub use syscalls::Syscall;
 
 /// Maximum payload size for structured panic.

--- a/rs/src/prelude.rs
+++ b/rs/src/prelude.rs
@@ -43,7 +43,7 @@ pub mod ffi {
 
 #[cfg(feature = "gstd")]
 pub use crate::gstd::{
-    CommandReply, EventEmitter, SailsEvent, Syscall, event, export, program, sails_type, service,
+    CommandReply, EventEmitter, SailsEvent, Syscall, event, export, program, service,
     services::Exposure as _, services::ExposureWithEvents as _,
 };
 pub use crate::types::*;
@@ -51,6 +51,7 @@ pub use gear_core_errors::{
     self as gear_core_errors, ErrorReplyReason, ReplyCode, SignalCode, SimpleExecutionError,
     SimpleUnavailableActorError, SuccessReplyReason,
 };
+pub use sails_macros::sails_type;
 
 pub use parity_scale_codec::{self as scale_codec, Decode, Encode, EncodeLike, Output};
 pub use sails_idl_meta::{Identifiable, InterfaceId, MethodMeta};

--- a/rs/src/prelude.rs
+++ b/rs/src/prelude.rs
@@ -43,7 +43,7 @@ pub mod ffi {
 
 #[cfg(feature = "gstd")]
 pub use crate::gstd::{
-    CommandReply, EventEmitter, SailsEvent, Syscall, event, export, program, service,
+    CommandReply, EventEmitter, SailsEvent, Syscall, event, export, program, sails_type, service,
     services::Exposure as _, services::ExposureWithEvents as _,
 };
 pub use crate::types::*;


### PR DESCRIPTION
Resolves #1287 

Two things to note:
- syntax for v1: `#[sails_type(no_reflect_hash)]`
- `sails-macros` is no longer an optional dep
