### PR TITLE
fix: strip .wasm/.opt extensions from program name

### DIFF
--- a/rs/src/builder.rs
+++ b/rs/src/builder.rs
@@ -96,7 +96,7 @@ impl<P: ProgramMeta> ClientBuilder<P> {
             .to_string_lossy()
             .split('.')
             .next()
-            .unwrap_or("")
+            .expect("path file_name must have at least one segment before a dot")
             .to_string();
 
         Self {
@@ -274,8 +274,6 @@ impl<P: ProgramMeta> ClientBuilder<P> {
 
 #[cfg(test)]
 mod tests {
-    use gstd::TypeInfo;
-
     use super::*;
 
     struct P;
@@ -304,5 +302,18 @@ mod tests {
         assert!(idl_path.is_some());
         assert!(client_path.unwrap().ends_with("src/sails_rs.rs"));
         assert!(idl_path.unwrap().ends_with("sails_rs.idl"));
+    }
+
+    #[test]
+    fn from_wasm_path_strips_extensions() {
+        let path = "target/release/foo.opt.wasm";
+        let builder = ClientBuilder::<P>::from_wasm_path(path);
+
+        // Program name must be clean - no .wasm / .opt suffixes
+        assert_eq!("foo", builder.program_name);
+
+        assert!(builder.idl_path.unwrap().ends_with("foo.idl"));
+        assert!(builder.client_path.unwrap().ends_with("foo.rs"));
+        assert!(builder.wasm_path.unwrap().ends_with("foo.opt.wasm"));
     }
 }

--- a/rs/src/builder.rs
+++ b/rs/src/builder.rs
@@ -94,12 +94,18 @@ impl<P: ProgramMeta> ClientBuilder<P> {
             .file_name()
             .expect("Invalid path to wasm")
             .to_string_lossy()
+            .split('.')
+            .next()
+            .unwrap_or("")
             .to_string();
 
         Self {
-            idl_path: Some(path.with_extension("idl")),
-            client_path: Some(path.with_extension("rs")),
-            wasm_path: Some(path.with_extension("opt.wasm")),
+            idl_path: Some(path.with_file_name(&program_name).with_extension("idl")),
+            client_path: Some(path.with_file_name(&program_name).with_extension("rs")),
+            wasm_path: Some(
+                path.with_file_name(&program_name)
+                    .with_extension("opt.wasm"),
+            ),
             program_name,
             no_std: false,
             _marker: Default::default(),


### PR DESCRIPTION
```bash
cargo install --path rs/cli

cargo sails new ~/tmp/test-bug --name test-bug --sails-path ./rs

cd ~/tmp/test-bug && cargo build --release

grep '^program' ~/tmp/test-bug/target/wasm32-gear/release/test_bug.idl

```