### PR TITLE
feat: migrate metadata from doc-comments to IDL annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ When this feature is active:
 >
 > The accepted value (tokens) depends on whether the `ethexe` feature is enabled. Without the feature, these are native VARA tokens; with the feature, these are ETH.
 
-- The generated IDL is enhanced with additional documentation to signify payable methods and methods that return value. Specifically, methods marked with `#[export(payable)]` will have a `/// #[payable]` doc comment, and methods returning `CommandReply<T>` will have a `/// #[returns_value]` doc comment. This metadata is necessary for the correct generation of Solidity interfaces via the `sails-sol-gen` crate.
+- The generated IDL is enhanced with structured annotations to signify payable methods, methods that return value, and indexed event fields. Specifically, methods marked with `#[export(payable)]` will have an `@payable` annotation, and methods returning `CommandReply<T>` will have a `@returns_value` annotation. Additionally, event fields marked with `#[indexed]` will have an `@indexed` annotation. This metadata is necessary for the correct generation of Solidity interfaces via the `sails-sol-gen` crate.
 
 Here is an example demonstrating these features:
 
@@ -656,9 +656,22 @@ impl MyProgram {
     }
 }
 
+#[event]
+#[derive(Clone, Debug, PartialEq, Encode, TypeInfo, ReflectHash)]
+#[reflect_hash(crate = sails_rs)]
+pub enum MyEvent {
+    Transfer {
+        #[indexed]
+        from: ActorId,
+        #[indexed]
+        to: ActorId,
+        amount: u128,
+    },
+}
+
 pub struct SomeService;
 
-#[service]
+#[service(events = MyEvent)]
 impl SomeService {
     #[export]
     pub async fn do_this(&mut self, p1: u32, _p2: String) -> u32 {
@@ -679,7 +692,7 @@ impl SomeService {
 ```
 
 In the example above, `create_payable` is a payable constructor, and `do_this_payable` is a payable service method.
-The `withdraw` method will have the `/// #[returns_value]` doc comment in the IDL.
+The `withdraw` method will have the `@returns_value` annotation in the IDL, and `from` and `to` fields in `MyEvent` will have `@indexed` annotations.
 For more details, you can refer to the full example at [`rs/ethexe/ethapp/src/lib.rs`](rs/ethexe/ethapp/src/lib.rs).
 
 ## Examples

--- a/benchmarks/ping-pong/client/ping_pong.idl
+++ b/benchmarks/ping-pong/client/ping_pong.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service PingPongService@0x6a72968a4c62e7d7 {
     functions {

--- a/examples/aggregator/client/aggregator_client.idl
+++ b/examples/aggregator/client/aggregator_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service Aggregator@0x8e5b7b94507d0323 {
     functions {

--- a/examples/demo/client/demo_client.idl
+++ b/examples/demo/client/demo_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service PingPong@0x6d0eb40dde4038f7 {
     functions {

--- a/examples/inspector/client/inspector_client.idl
+++ b/examples/inspector/client/inspector_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service Inspector@0xdf7978e4f1d11ddd {
     functions {

--- a/examples/no-svcs-prog/wasm/no_svcs_prog.idl
+++ b/examples/no-svcs-prog/wasm/no_svcs_prog.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 program NoSvcsProg {
     constructors {

--- a/examples/redirect/client/redirect_client.idl
+++ b/examples/redirect/client/redirect_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service Redirect@0xba58dee1cb75511e {
     functions {

--- a/examples/redirect/proxy-client/redirect_proxy_client.idl
+++ b/examples/redirect/proxy-client/redirect_proxy_client.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service Proxy@0x73843476ff137c7e {
     functions {

--- a/examples/rmrk/catalog/wasm/rmrk-catalog.idl
+++ b/examples/rmrk/catalog/wasm/rmrk-catalog.idl
@@ -1,5 +1,5 @@
 
-!@sails: 1.0.0-beta.2
+!@sails: 1.0.0-beta.3
 
 service RmrkCatalog@0xb810a541ab5d5389 {
     functions {

--- a/rs/ethexe/ethapp_with_events/tests/snapshots/insta__ethapp_with_events_generate_idl.snap
+++ b/rs/ethexe/ethapp_with_events/tests/snapshots/insta__ethapp_with_events_generate_idl.snap
@@ -9,7 +9,7 @@ service Svc1@0x349b842b767fb2ab {
     events {
         DoThisEvent {
             /// Some u32 value
-            /// #[indexed]
+            @indexed
             p1: u32,
             p2: String,
         },

--- a/rs/ethexe/macros-tests/tests/snapshots/eth_event__eth_event_indexed.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/eth_event__eth_event_indexed.snap
@@ -4,9 +4,9 @@ expression: result
 ---
 pub enum Events {
     MyEvent1 {
-        #[type_info(indexed)]
+        #[annotate(indexed)]
         sender: u128,
-        #[type_info(indexed)]
+        #[annotate(indexed)]
         amount: u128,
         note: String,
     },

--- a/rs/ethexe/macros-tests/tests/snapshots/eth_event__eth_event_indexed.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/eth_event__eth_event_indexed.snap
@@ -4,9 +4,9 @@ expression: result
 ---
 pub enum Events {
     MyEvent1 {
-        /// #[indexed]
+        #[type_info(indexed)]
         sender: u128,
-        /// #[indexed]
+        #[type_info(indexed)]
         amount: u128,
         note: String,
     },

--- a/rs/ethexe/macros-tests/tests/snapshots/eth_event__eth_event_sails_rename.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/eth_event__eth_event_sails_rename.snap
@@ -4,9 +4,9 @@ expression: result
 ---
 pub enum Events {
     MyEvent1 {
-        #[type_info(indexed)]
+        #[annotate(indexed)]
         sender: u128,
-        #[type_info(indexed)]
+        #[annotate(indexed)]
         amount: u128,
         note: String,
     },

--- a/rs/ethexe/macros-tests/tests/snapshots/eth_event__eth_event_sails_rename.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/eth_event__eth_event_sails_rename.snap
@@ -4,9 +4,9 @@ expression: result
 ---
 pub enum Events {
     MyEvent1 {
-        /// #[indexed]
+        #[type_info(indexed)]
         sender: u128,
-        /// #[indexed]
+        #[type_info(indexed)]
         amount: u128,
         note: String,
     },

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
@@ -265,7 +265,7 @@ mod some_service_meta {
     #[derive(sails_rs::TypeInfo)]
     #[type_info(crate = sails_rs::type_info)]
     pub enum CommandsMeta {
-        /// #[returns_value]
+        #[type_info(returns_value)]
         DoThis(__DoThisParams, u32),
     }
     #[derive(sails_rs::TypeInfo)]

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
@@ -265,7 +265,7 @@ mod some_service_meta {
     #[derive(sails_rs::TypeInfo)]
     #[type_info(crate = sails_rs::type_info)]
     pub enum CommandsMeta {
-        #[type_info(returns_value)]
+        #[annotate(returns_value)]
         DoThis(__DoThisParams, u32),
     }
     #[derive(sails_rs::TypeInfo)]

--- a/rs/macros/core/src/event/ethexe.rs
+++ b/rs/macros/core/src/event/ethexe.rs
@@ -192,13 +192,13 @@ pub(super) fn process_indexed(input: &mut ItemEnum) {
             // For named fields, use the field identifiers directly.
             Fields::Named(named) => {
                 for field in named.named.iter_mut().filter(|f| is_indexed(f)) {
-                    remove_indexed_and_add_comment(field);
+                    replace_indexed_with_type_info(field);
                 }
             }
             // For unnamed (tuple) fields, create synthetic identifiers.
             Fields::Unnamed(unnamed) => {
                 for field in unnamed.unnamed.iter_mut().filter(|f| is_indexed(f)) {
-                    remove_indexed_and_add_comment(field);
+                    replace_indexed_with_type_info(field);
                 }
             }
             // For unit variants, no fields exist.
@@ -207,8 +207,8 @@ pub(super) fn process_indexed(input: &mut ItemEnum) {
     }
 }
 
-/// remove indexed attribute from field and add type_info annotation
-fn remove_indexed_and_add_comment(field: &mut syn::Field) {
+/// remove indexed attribute from field and add type_info attribute
+fn replace_indexed_with_type_info(field: &mut syn::Field) {
     field.attrs.retain(|attr| !attr.path().is_ident("indexed"));
     field.attrs.push(syn::parse_quote! {
         #[type_info(indexed)]
@@ -239,7 +239,7 @@ mod tests {
                 SomeEvent
                 {
                     /// Some comment
-                    /// #[indexed]
+                    #[type_info(indexed)]
                     sender: u128
                 },
             }

--- a/rs/macros/core/src/event/ethexe.rs
+++ b/rs/macros/core/src/event/ethexe.rs
@@ -207,11 +207,11 @@ pub(super) fn process_indexed(input: &mut ItemEnum) {
     }
 }
 
-/// remove indexed attribute from field and add comment
+/// remove indexed attribute from field and add type_info annotation
 fn remove_indexed_and_add_comment(field: &mut syn::Field) {
     field.attrs.retain(|attr| !attr.path().is_ident("indexed"));
     field.attrs.push(syn::parse_quote! {
-        #[doc = r" #[indexed]"]
+        #[type_info(indexed)]
     });
 }
 

--- a/rs/macros/core/src/event/ethexe.rs
+++ b/rs/macros/core/src/event/ethexe.rs
@@ -211,7 +211,7 @@ pub(super) fn process_indexed(input: &mut ItemEnum) {
 fn replace_indexed_with_type_info(field: &mut syn::Field) {
     field.attrs.retain(|attr| !attr.path().is_ident("indexed"));
     field.attrs.push(syn::parse_quote! {
-        #[type_info(indexed)]
+        #[annotate(indexed)]
     });
 }
 
@@ -239,7 +239,7 @@ mod tests {
                 SomeEvent
                 {
                     /// Some comment
-                    #[type_info(indexed)]
+                    #[annotate(indexed)]
                     sender: u128
                 },
             }

--- a/rs/macros/core/src/program/mod.rs
+++ b/rs/macros/core/src/program/mod.rs
@@ -762,7 +762,7 @@ impl FnBuilder<'_> {
         let params_struct_ident = &self.params_struct_ident;
 
         #[cfg(feature = "ethexe")]
-        let payable_ann = self.payable.then(|| quote!(#[type_info(payable)]));
+        let payable_ann = self.payable.then(|| quote!(#[annotate(payable)]));
         #[cfg(not(feature = "ethexe"))]
         let payable_ann: Option<TokenStream2> = None;
 

--- a/rs/macros/core/src/program/mod.rs
+++ b/rs/macros/core/src/program/mod.rs
@@ -761,15 +761,22 @@ impl FnBuilder<'_> {
             .filter(|attr| attr.path().is_ident("doc"));
         let params_struct_ident = &self.params_struct_ident;
 
+        #[cfg(feature = "ethexe")]
+        let payable_ann = self.payable.then(|| quote!(#[type_info(payable)]));
+        #[cfg(not(feature = "ethexe"))]
+        let payable_ann: Option<TokenStream2> = None;
+
         if let Some(err_ty) = &self.error_type {
             let err_ty = shared::replace_any_lifetime_with_static(err_ty.clone());
             quote! {
                 #( #ctor_docs_attrs )*
+                #payable_ann
                 #ctor_route(#params_struct_ident, #err_ty)
             }
         } else {
             quote! {
                 #( #ctor_docs_attrs )*
+                #payable_ann
                 #ctor_route(#params_struct_ident)
             }
         }

--- a/rs/macros/core/src/service/mod.rs
+++ b/rs/macros/core/src/service/mod.rs
@@ -217,14 +217,14 @@ impl FnBuilder<'_> {
         let result_type = self.result_type_with_static_lifetime();
 
         #[cfg(feature = "ethexe")]
-        let payable_ann = self.payable.then(|| quote!(#[type_info(payable)]));
+        let payable_ann = self.payable.then(|| quote!(#[annotate(payable)]));
         #[cfg(not(feature = "ethexe"))]
         let payable_ann: Option<TokenStream> = None;
 
         let returns_value_ann = if cfg!(feature = "ethexe") {
             self.result_type_with_value()
                 .1
-                .then(|| quote!(#[type_info(returns_value)]))
+                .then(|| quote!(#[annotate(returns_value)]))
         } else {
             None
         };

--- a/rs/macros/core/src/service/mod.rs
+++ b/rs/macros/core/src/service/mod.rs
@@ -217,14 +217,14 @@ impl FnBuilder<'_> {
         let result_type = self.result_type_with_static_lifetime();
 
         #[cfg(feature = "ethexe")]
-        let payable_doc = self.payable.then(|| quote!(#[doc = " #[payable]"]));
+        let payable_ann = self.payable.then(|| quote!(#[type_info(payable)]));
         #[cfg(not(feature = "ethexe"))]
-        let payable_doc: Option<TokenStream> = None;
+        let payable_ann: Option<TokenStream> = None;
 
-        let returns_value_doc = if cfg!(feature = "ethexe") {
+        let returns_value_ann = if cfg!(feature = "ethexe") {
             self.result_type_with_value()
                 .1
-                .then(|| quote!(#[doc = " #[returns_value]"]))
+                .then(|| quote!(#[type_info(returns_value)]))
         } else {
             None
         };
@@ -233,15 +233,15 @@ impl FnBuilder<'_> {
             let err_ty = shared::replace_any_lifetime_with_static(err_ty.clone());
             quote!(
                 #( #handler_docs_attrs )*
-                #payable_doc
-                #returns_value_doc
+                #payable_ann
+                #returns_value_ann
                 #handler_route_ident(#params_struct_ident, #result_type, #err_ty)
             )
         } else {
             quote!(
                 #( #handler_docs_attrs )*
-                #payable_doc
-                #returns_value_doc
+                #payable_ann
+                #returns_value_ann
                 #handler_route_ident(#params_struct_ident, #result_type)
             )
         }

--- a/rs/sol-gen/src/lib.rs
+++ b/rs/sol-gen/src/lib.rs
@@ -145,7 +145,7 @@ fn events_from_idl(doc: &IdlDoc) -> Result<Vec<EventData>> {
             for f in &e.def.fields {
                 let arg = EventArgData {
                     ty: f.type_decl.get_ty()?,
-                    indexed: f.docs.iter().any(|doc| doc.contains("#[indexed]")),
+                    indexed: f.annotations.iter().any(|(k, _)| k == "indexed"),
                     name: f.name.as_ref().map(|name| name.to_case(Case::Camel)),
                 };
                 args.push(arg);

--- a/rs/sol-gen/src/lib.rs
+++ b/rs/sol-gen/src/lib.rs
@@ -97,7 +97,7 @@ fn functions_from_idl(doc: &IdlDoc) -> Result<Vec<FunctionData>> {
                 name: func.name.to_case(Case::Camel),
                 reply_type: None, // Constructors don't have replies in this sense
                 reply_mem_location: None,
-                payable: has_tag(&func.docs, "#[payable]"),
+                payable: func.annotations.iter().any(|(k, _)| k == "payable"),
                 returns_value: false, // Constructors don't return CommandReply values
                 args,
             });
@@ -126,8 +126,8 @@ fn functions_from_idl(doc: &IdlDoc) -> Result<Vec<FunctionData>> {
                     .to_case(Case::Camel),
                 reply_type,
                 reply_mem_location: f.output.get_mem_location(),
-                payable: has_tag(&f.docs, "#[payable]"),
-                returns_value: has_tag(&f.docs, "#[returns_value]"),
+                payable: f.annotations.iter().any(|(k, _)| k == "payable"),
+                returns_value: f.annotations.iter().any(|(k, _)| k == "returns_value"),
                 args,
             });
         }
@@ -158,8 +158,4 @@ fn events_from_idl(doc: &IdlDoc) -> Result<Vec<EventData>> {
     }
 
     Ok(events)
-}
-
-fn has_tag(docs: &[String], tag: &str) -> bool {
-    docs.iter().any(|doc| doc.contains(tag))
 }

--- a/rs/sol-gen/tests/generator.rs
+++ b/rs/sol-gen/tests/generator.rs
@@ -102,7 +102,7 @@ fn test_generate_contract_w_mixed_indexed_events() {
 const PAYABLE_IDL: &str = r#"
 program TestProgram {
     constructors {
-        /// #[payable]
+        @payable
         Create();
     }
     services {
@@ -112,14 +112,14 @@ program TestProgram {
 
 service MyService {
     functions {
-        /// #[payable]
+        @payable
         Deposit() -> ();
 
-        /// #[returns_value]
+        @returns_value
         Withdraw() -> u128;
 
-        /// #[payable]
-        /// #[returns_value]
+        @payable
+        @returns_value
         SwapAndRefund() -> u128;
 
         @query

--- a/rs/sol-gen/tests/generator.rs
+++ b/rs/sol-gen/tests/generator.rs
@@ -76,10 +76,10 @@ program TestProgram {
 service Svc {
     events {
         MixedEvent {
-            /// #[indexed]
+            @indexed
             f1: u32,
             f2: String,
-            /// #[indexed]
+            @indexed
             f3: u128,
             f4: u128
         }

--- a/rs/type-registry/derive/src/lib.rs
+++ b/rs/type-registry/derive/src/lib.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::{Data, DeriveInput, Fields, GenericParam, Ident, Type, parse_macro_input};
 
-#[proc_macro_derive(TypeInfo, attributes(type_info))]
+#[proc_macro_derive(TypeInfo, attributes(type_info, annotate))]
 pub fn type_info_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match process_derive(input) {
@@ -108,8 +108,6 @@ fn resolve_registry_path(input: &DeriveInput) -> syn::Result<TokenStream2> {
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("crate") {
                     path = Some(meta.value()?.parse::<syn::Path>()?);
-                } else if meta.input.peek(syn::Token![=]) {
-                    let _: syn::Expr = meta.value()?.parse()?;
                 }
                 Ok(())
             })?;
@@ -159,17 +157,13 @@ fn extract_docs(attrs: &[syn::Attribute]) -> Vec<TokenStream2> {
 
 fn extract_annotations(attrs: &[syn::Attribute]) -> syn::Result<Vec<TokenStream2>> {
     let mut anns = Vec::new();
-    for attr in attrs.iter().filter(|a| a.path().is_ident("type_info")) {
+    for attr in attrs.iter().filter(|a| a.path().is_ident("annotate")) {
         attr.parse_nested_meta(|meta| {
             let ident = meta
                 .path
                 .get_ident()
                 .ok_or_else(|| meta.error("expected identifier"))?;
             let ident_str = ident.to_string();
-            if ident_str == "crate" {
-                let _: syn::Path = meta.value()?.parse()?;
-                return Ok(());
-            }
 
             if meta.input.peek(syn::Token![=]) {
                 let value: syn::Expr = meta.value()?.parse()?;
@@ -457,7 +451,7 @@ mod tests {
                 /// Second line of documentation
                 struct Basic<T> {
                     /// Simple field
-                    #[type_info(name = "custom")]
+                    #[annotate(name = "custom")]
                     a: u32,
                     /// Direct parameter
                     b: T,
@@ -488,12 +482,12 @@ mod tests {
     fn complex_enum() {
         assert_expansion(
             parse_quote! {
-                #[type_info(top = "val")]
+                #[annotate(top = "val")]
                 enum Complex {
                     /// Variant with named fields and annotations
-                    #[type_info(v1)]
+                    #[annotate(v1)]
                     V1 {
-                        #[type_info(f1 = "v")]
+                        #[annotate(f1 = "v")]
                         f: u32
                     },
                     /// Variant with unnamed fields
@@ -534,14 +528,14 @@ mod tests {
             parse_quote! {
                 /// The Container Type
                 #[type_info(crate = sails_rs::type_info)]
-                #[type_info(attr1 = "val1", attr2)]
+                #[annotate(attr1 = "val1", attr2)]
                 pub struct Container<T, U, const SIZE: usize>
                 where T: Clone
                 {
                     /// Recursive field
                     pub next: Option<Box<Container<T, U, SIZE>>>,
                     /// Field with many annotations
-                    #[type_info(indexed, secret = "true", range = "0..100")]
+                    #[annotate(indexed, secret = "true", range = "0..100")]
                     pub data: [T; SIZE],
                     pub mapped: BTreeMap<String, U>,
                     /// Tuple field

--- a/rs/type-registry/tests/annotations.rs
+++ b/rs/type-registry/tests/annotations.rs
@@ -4,7 +4,7 @@ use sails_type_registry::{Registry, TypeInfo};
 #[test]
 fn test_struct_annotation() {
     #[derive(TypeInfo)]
-    #[type_info(indexed)]
+    #[annotate(indexed)]
     struct Indexed {
         _x: u32,
     }
@@ -19,8 +19,8 @@ fn test_struct_annotation() {
 #[test]
 fn test_multiple_annotations_on_struct() {
     #[derive(TypeInfo)]
-    #[type_info(compressed)]
-    #[type_info(versioned)]
+    #[annotate(compressed)]
+    #[annotate(versioned)]
     struct MultiAnnotated {
         _data: u32,
     }
@@ -38,7 +38,7 @@ fn test_multiple_annotations_on_struct() {
 #[test]
 fn test_enum_annotation() {
     #[derive(TypeInfo)]
-    #[type_info(sealed)]
+    #[annotate(sealed)]
     enum Sealed {
         _A,
         _B,
@@ -55,7 +55,7 @@ fn test_enum_annotation() {
 fn test_variant_annotation() {
     #[derive(TypeInfo)]
     enum Tagged {
-        #[type_info(deprecated)]
+        #[annotate(deprecated)]
         _Old,
         _New,
     }
@@ -76,7 +76,7 @@ fn test_variant_annotation() {
 fn test_field_annotation() {
     #[derive(TypeInfo)]
     struct WithFieldAnnotation {
-        #[type_info(sensitive)]
+        #[annotate(sensitive)]
         _secret: u64,
         _public: u32,
     }
@@ -110,7 +110,7 @@ fn test_no_annotations_by_default() {
 #[test]
 fn test_annotation_with_value() {
     #[derive(TypeInfo)]
-    #[type_info(version = "2")]
+    #[annotate(version = "2")]
     struct Versioned {
         _x: u32,
     }

--- a/rs/type-registry/tests/ui/invalid_annotation.rs
+++ b/rs/type-registry/tests/ui/invalid_annotation.rs
@@ -1,7 +1,7 @@
 use sails_type_registry::TypeInfo;
 
 #[derive(TypeInfo)]
-#[type_info(id = 42)] // Integer values are not supported
+#[annotate(id = 42)] // Integer values are not supported
 struct User {
     id: u32,
 }

--- a/rs/type-registry/tests/ui/invalid_annotation.stderr
+++ b/rs/type-registry/tests/ui/invalid_annotation.stderr
@@ -1,5 +1,5 @@
 error: expected string literal
- --> tests/ui/invalid_annotation.rs:4:13
+ --> tests/ui/invalid_annotation.rs:4:12
   |
-4 | #[type_info(id = 42)] // Integer values are not supported
-  |             ^^^^^^^
+4 | #[annotate(id = 42)] // Integer values are not supported
+  |            ^^^^^^^


### PR DESCRIPTION
The current implementation uses doc-comment string matching (/// #[payable]) to pass system metadata to generators. This task migrates these to structured annotations (`@payable`, `@indexed`) using the `type-registry` system to separate human-readable documentation from system-level logic.
