### PR TITLE
feat: Extend #[export] with per-function transport/encoding opt-in (scale and ethabi)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6484,6 +6484,7 @@ dependencies = [
 name = "sails-reflect-hash"
 version = "1.0.0-beta.3"
 dependencies = [
+ "alloy-primitives",
  "gprimitives",
  "keccak-const",
  "sails-reflect-hash-derive",
@@ -6554,6 +6555,7 @@ dependencies = [
 name = "sails-type-registry"
 version = "1.0.0-beta.3"
 dependencies = [
+ "alloy-primitives",
  "gprimitives",
  "insta",
  "sails-type-registry-derive",

--- a/README.md
+++ b/README.md
@@ -623,13 +623,23 @@ The `ethexe` cargo feature enables several features:
 When this feature is active:
 
 - Identifiers for **program constructors** and **exposed service constructors** (methods within a `#[program]` block that return a service) are validated against Solidity reserved keywords. Using a reserved name for these (e.g., `new` for a program constructor, or `function` for an exposed service constructor) will result in a compilation error, preventing naming conflicts in the generated Solidity interface. The comprehensive list of these reserved keywords can be found in the [source code](rs/macros/core/src/shared.rs) (see the `SOL_KEYWORDS` constant).
-- The `#[export]` macro accepts a `payable` argument (`#[export(payable)]`). This allows service methods and program constructors to accept value with a message. If a non-payable method or constructor receives value, the execution will panic.
+- The `#[export]` macro supports **transport selection** and `payable` methods via its arguments:
+  - `#[export(scale)]` — expose the method only through the Gear/SCALE dispatch path.
+  - `#[export(ethabi)]` — expose the method only through the Solidity ABI dispatch path.
+  - `#[export(scale, ethabi)]` — expose through both paths (same as bare `#[export]`).
+  - `#[export(payable)]` or `#[export(ethabi, payable)]` — mark the method as payable. `payable` requires `ethabi` transport; writing `#[export(scale, payable)]` is a compile error.
+
+  Transport flags control **runtime dispatch visibility only**. All exported methods remain in the service's IDL metadata, interface hash, and method metadata regardless of their transport selection. Single-transport methods receive an `@scale` or `@ethabi` annotation in the generated IDL.
+
+  Without the `ethexe` feature, only `#[export]` and `#[export(scale)]` are accepted; the `ethabi` and `payable` flags are unavailable.
+
+  Ethabi-only methods (`#[export(ethabi)]`) do not require their parameter and return types to implement SCALE `Encode`/`Decode`, allowing the use of ABI-native types such as `alloy_primitives::Address` and `alloy_primitives::B256`.
 
 > **NOTE**
 >
 > The accepted value (tokens) depends on whether the `ethexe` feature is enabled. Without the feature, these are native VARA tokens; with the feature, these are ETH.
 
-- The generated IDL is enhanced with structured annotations to signify payable methods, methods that return value, and indexed event fields. Specifically, methods marked with `#[export(payable)]` will have an `@payable` annotation, and methods returning `CommandReply<T>` will have a `@returns_value` annotation. Additionally, event fields marked with `#[indexed]` will have an `@indexed` annotation. This metadata is necessary for the correct generation of Solidity interfaces via the `sails-sol-gen` crate.
+- The generated IDL is enhanced with structured annotations to signify payable methods, methods that return value, transport-restricted methods, and indexed event fields. Specifically, methods marked with `#[export(payable)]` will have an `@payable` annotation, methods returning `CommandReply<T>` will have a `@returns_value` annotation, and single-transport methods will have an `@scale` or `@ethabi` annotation. Additionally, event fields marked with `#[indexed]` will have an `@indexed` annotation. This metadata is necessary for the correct generation of Solidity interfaces via the `sails-sol-gen` crate.
 
 Here is an example demonstrating these features:
 
@@ -673,14 +683,28 @@ pub struct SomeService;
 
 #[service(events = MyEvent)]
 impl SomeService {
+    // Available through both SCALE and Solidity ABI dispatch (default)
     #[export]
     pub async fn do_this(&mut self, p1: u32, _p2: String) -> u32 {
         p1
     }
 
+    // Payable method, available through both dispatch paths
     #[export(payable)]
     pub fn do_this_payable(&mut self, p1: u32) -> u32 {
         p1
+    }
+
+    // SCALE dispatch only — not exposed to Solidity callers
+    #[export(scale)]
+    pub fn gear_only(&self) -> u32 {
+        42
+    }
+
+    // Solidity ABI dispatch only — not exposed to Gear/SCALE callers
+    #[export(ethabi)]
+    pub fn eth_only(&self) -> u32 {
+        42
     }
 
     // This method implicitly `returns_value` because of its return type
@@ -692,6 +716,7 @@ impl SomeService {
 ```
 
 In the example above, `create_payable` is a payable constructor, and `do_this_payable` is a payable service method.
+The `gear_only` method is only reachable via Gear/SCALE messages, while `eth_only` is only reachable via Solidity ABI calls. Both still appear in the service's IDL and contribute to its interface hash.
 The `withdraw` method will have the `@returns_value` annotation in the IDL, and `from` and `to` fields in `MyEvent` will have `@indexed` annotations.
 For more details, you can refer to the full example at [`rs/ethexe/ethapp/src/lib.rs`](rs/ethexe/ethapp/src/lib.rs).
 

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ When this feature is active:
   - `#[export(scale, ethabi)]` — expose through both paths (same as bare `#[export]`).
   - `#[export(payable)]` or `#[export(ethabi, payable)]` — mark the method as payable. `payable` requires `ethabi` transport; writing `#[export(scale, payable)]` is a compile error.
 
-  Transport flags control **runtime dispatch visibility only**. All exported methods remain in the service's IDL metadata, interface hash, and method metadata regardless of their transport selection. Single-transport methods receive an `@scale` or `@ethabi` annotation in the generated IDL.
+  Transport flags control **runtime dispatch visibility only**. All exported methods remain in the service's IDL metadata, interface hash, and method metadata regardless of their transport selection. Single-transport methods receive a `@codec: scale` or `@codec: ethabi` annotation in the generated IDL.
 
   Without the `ethexe` feature, only `#[export]` and `#[export(scale)]` are accepted; the `ethabi` and `payable` flags are unavailable.
 
@@ -639,7 +639,7 @@ When this feature is active:
 >
 > The accepted value (tokens) depends on whether the `ethexe` feature is enabled. Without the feature, these are native VARA tokens; with the feature, these are ETH.
 
-- The generated IDL is enhanced with structured annotations to signify payable methods, methods that return value, transport-restricted methods, and indexed event fields. Specifically, methods marked with `#[export(payable)]` will have an `@payable` annotation, methods returning `CommandReply<T>` will have a `@returns_value` annotation, and single-transport methods will have an `@scale` or `@ethabi` annotation. Additionally, event fields marked with `#[indexed]` will have an `@indexed` annotation. This metadata is necessary for the correct generation of Solidity interfaces via the `sails-sol-gen` crate.
+- The generated IDL is enhanced with structured annotations to signify payable methods, methods that return value, transport-restricted methods, and indexed event fields. Specifically, methods marked with `#[export(payable)]` will have an `@payable` annotation, methods returning `CommandReply<T>` will have a `@returns_value` annotation, and single-transport methods will have a `@codec: scale` or `@codec: ethabi` annotation. Additionally, event fields marked with `#[indexed]` will have an `@indexed` annotation. This metadata is necessary for the correct generation of Solidity interfaces via the `sails-sol-gen` crate.
 
 Here is an example demonstrating these features:
 

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -61,6 +61,8 @@ ethexe = [
     "dep:alloy-primitives",
     "dep:alloy-sol-types",
     "sails-macros/ethexe",
+    "sails-reflect-hash/alloy-primitives",
+    "sails-type-registry/alloy-primitives",
 ]
 gclient = ["dep:gclient", "dep:tokio-stream"]
 gstd = ["dep:gstd", "dep:gear-core"]

--- a/rs/ethexe/Cargo.lock
+++ b/rs/ethexe/Cargo.lock
@@ -4620,6 +4620,7 @@ dependencies = [
 name = "sails-reflect-hash"
 version = "1.0.0-beta.3"
 dependencies = [
+ "alloy-primitives",
  "gprimitives",
  "keccak-const",
  "sails-reflect-hash-derive",
@@ -4671,6 +4672,7 @@ dependencies = [
 name = "sails-type-registry"
 version = "1.0.0-beta.3"
 dependencies = [
+ "alloy-primitives",
  "gprimitives",
  "sails-type-registry-derive",
 ]

--- a/rs/ethexe/macros-tests/tests/service_insta.rs
+++ b/rs/ethexe/macros-tests/tests/service_insta.rs
@@ -25,6 +25,109 @@ fn works_with_basics() {
 }
 
 #[test]
+fn works_with_explicit_scale_only() {
+    let input = quote! {
+        impl SomeService {
+            #[export(scale)]
+            pub fn scale_method(&self, p1: u32) -> u32 {
+                p1
+            }
+        }
+    };
+
+    let result = gservice(TokenStream::new(), input).to_string();
+    let result = prettyplease::unparse(&syn::parse_str(&result).unwrap());
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn works_with_explicit_ethabi_only() {
+    let input = quote! {
+        impl SomeService {
+            #[export(ethabi)]
+            pub fn ethabi_method(&self, p1: u32) -> u32 {
+                p1
+            }
+        }
+    };
+
+    let result = gservice(TokenStream::new(), input).to_string();
+    let result = prettyplease::unparse(&syn::parse_str(&result).unwrap());
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn works_with_explicit_dual_export() {
+    let input = quote! {
+        impl SomeService {
+            #[export(scale, ethabi)]
+            pub fn dual_method(&self, p1: u32) -> u32 {
+                p1
+            }
+        }
+    };
+
+    let result = gservice(TokenStream::new(), input).to_string();
+    let result = prettyplease::unparse(&syn::parse_str(&result).unwrap());
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn works_with_mixed_transports() {
+    let input = quote! {
+        impl SomeService {
+            #[export(scale)]
+            pub fn scale_only(&self, p1: u32) -> u32 {
+                p1
+            }
+
+            #[export(ethabi)]
+            pub fn ethabi_only(&self, p1: u32) -> u32 {
+                p1
+            }
+
+            #[export(scale, ethabi)]
+            pub fn dual(&self, p1: u32) -> u32 {
+                p1
+            }
+
+            #[export]
+            pub fn default_both(&self, p1: u32) -> u32 {
+                p1
+            }
+        }
+    };
+
+    let result = gservice(TokenStream::new(), input).to_string();
+    let result = prettyplease::unparse(&syn::parse_str(&result).unwrap());
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn works_with_ethabi_only_non_scale_type() {
+    let input = quote! {
+        impl SomeService {
+            #[export(ethabi)]
+            pub fn abi_method(
+                &self,
+                addr: sails_rs::alloy_primitives::Address,
+            ) -> sails_rs::alloy_primitives::B256 {
+                sails_rs::alloy_primitives::B256::ZERO
+            }
+        }
+    };
+
+    let result = gservice(TokenStream::new(), input).to_string();
+    let result = prettyplease::unparse(&syn::parse_str(&result).unwrap());
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
 fn works_with_lifetimes_and_generics() {
     let input = quote! {
         impl<'a, 'b, T, U> SomeService<'a, 'b, T, U>

--- a/rs/ethexe/macros-tests/tests/service_tests.rs
+++ b/rs/ethexe/macros-tests/tests/service_tests.rs
@@ -15,6 +15,7 @@ mod service_with_extends_and_lifetimes;
 mod service_with_lifecycles_and_generics;
 mod service_with_reply_with_value;
 mod service_with_trait_bounds;
+mod service_with_transport_selection;
 
 #[tokio::test]
 async fn service_with_basics() {
@@ -323,4 +324,68 @@ async fn service_with_trait_bounds() {
 
     let result = sails_rs::alloy_sol_types::SolValue::abi_decode(output.as_slice());
     assert_eq!(Ok(42u32), result);
+}
+
+#[test]
+fn service_transport_selection_runtime_dispatch() {
+    use sails_rs::{
+        Encode,
+        alloy_sol_types::SolValue,
+        gstd::services::Service,
+        meta::{Identifiable, ServiceMeta, find_method_data},
+    };
+    use service_with_transport_selection::MyService;
+
+    fn ignore_result(_: &[u8], _: u128) {}
+
+    let methods = <MyService as ServiceMeta>::METHODS;
+    let scale_only = find_method_data(methods, "ScaleOnly", None)
+        .unwrap()
+        .entry_id;
+    let ethabi_only = find_method_data(methods, "EthabiOnly", None)
+        .unwrap()
+        .entry_id;
+    let dual = find_method_data(methods, "Dual", None).unwrap().entry_id;
+    let interface_id = <MyService as Identifiable>::INTERFACE_ID;
+
+    let scale_input = 7u32.encode();
+    let abi_input = (false, 7u32).abi_encode_sequence();
+
+    assert!(
+        MyService
+            .expose(1)
+            .try_handle(interface_id, scale_only, &scale_input, ignore_result)
+            .is_some()
+    );
+    assert!(
+        MyService
+            .expose(1)
+            .try_handle(interface_id, ethabi_only, &scale_input, ignore_result)
+            .is_none()
+    );
+    assert!(
+        MyService
+            .expose(1)
+            .try_handle(interface_id, dual, &scale_input, ignore_result)
+            .is_some()
+    );
+
+    assert!(
+        MyService
+            .expose(1)
+            .try_handle_solidity(interface_id, scale_only, &abi_input)
+            .is_none()
+    );
+    assert!(
+        MyService
+            .expose(1)
+            .try_handle_solidity(interface_id, ethabi_only, &abi_input)
+            .is_some()
+    );
+    assert!(
+        MyService
+            .expose(1)
+            .try_handle_solidity(interface_id, dual, &abi_input)
+            .is_some()
+    );
 }

--- a/rs/ethexe/macros-tests/tests/service_with_transport_selection/mod.rs
+++ b/rs/ethexe/macros-tests/tests/service_with_transport_selection/mod.rs
@@ -1,0 +1,21 @@
+use sails_rs::prelude::*;
+
+pub struct MyService;
+
+#[sails_rs::service]
+impl MyService {
+    #[export(scale)]
+    pub fn scale_only(&self, p1: u32) -> u32 {
+        p1 + 1
+    }
+
+    #[export(ethabi)]
+    pub fn ethabi_only(&self, p1: u32) -> u32 {
+        p1 + 2
+    }
+
+    #[export(scale, ethabi)]
+    pub fn dual(&self, p1: u32) -> u32 {
+        p1 + 3
+    }
+}

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_allow_attrs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_allow_attrs.snap
@@ -62,7 +62,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -76,7 +76,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -96,7 +100,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -110,7 +114,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this(request.p1, request.p2).await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_basics.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_basics.snap
@@ -59,7 +59,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -73,7 +73,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -93,7 +97,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -107,7 +111,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this(request.p1, request.p2).await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_crate_path.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_crate_path.snap
@@ -59,7 +59,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rename::gstd::{InvocationIo, CommandReply};
+        use sails_rename::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -73,7 +73,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rename::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rename::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rename::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -93,7 +97,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rename::gstd::{InvocationIo, CommandReply};
+        use sails_rename::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -107,7 +111,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this(request.p1, request.p2).await;
                 let value = 0u128;
                 if !sails_rename::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rename::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rename::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_docs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_docs.snap
@@ -62,7 +62,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -76,7 +76,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -96,7 +100,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -110,7 +114,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this(request.p1, request.p2).await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_ethabi_only_non_scale_type.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_ethabi_only_non_scale_type.snap
@@ -180,7 +180,7 @@ mod some_service_meta {
     #[derive(sails_rs::TypeInfo)]
     #[type_info(crate = sails_rs::type_info)]
     pub enum QueriesMeta {
-        #[annotate(ethabi)]
+        #[annotate(codec = "ethabi")]
         AbiMethod(__AbiMethodParams, sails_rs::alloy_primitives::B256),
     }
     #[derive(sails_rs::TypeInfo)]

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_ethabi_only_non_scale_type.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_ethabi_only_non_scale_type.snap
@@ -1,0 +1,207 @@
+---
+source: macros-tests/tests/service_insta.rs
+expression: result
+---
+pub struct SomeServiceExposure<T> {
+    route_idx: u8,
+    inner: T,
+}
+impl<T: sails_rs::meta::ServiceMeta> sails_rs::gstd::services::Exposure
+for SomeServiceExposure<T> {
+    fn interface_id() -> sails_rs::meta::InterfaceId {
+        <T as sails_rs::meta::Identifiable>::INTERFACE_ID
+    }
+    fn route_idx(&self) -> u8 {
+        self.route_idx
+    }
+    fn check_asyncness(
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+    ) -> Option<bool> {
+        if !T::ASYNC {
+            return Some(false);
+        }
+        match (interface_id, entry_id) {
+            (id, 0u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(false)
+            }
+            _ => None,
+        }
+    }
+}
+impl<T> core::ops::Deref for SomeServiceExposure<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<T> core::ops::DerefMut for SomeServiceExposure<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl SomeServiceExposure<SomeService> {
+    #[export(ethabi)]
+    pub fn abi_method(
+        &self,
+        addr: sails_rs::alloy_primitives::Address,
+    ) -> sails_rs::alloy_primitives::B256 {
+        sails_rs::alloy_primitives::B256::ZERO
+    }
+    pub fn try_handle(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+    pub async fn try_handle_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+    pub fn try_handle_solidity(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            (
+                id,
+                0u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let (
+                    __encode_reply,
+                    addr,
+                ): (
+                    bool,
+                    <<sails_rs::alloy_primitives::Address as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::RustType,
+                ) = sails_rs::alloy_sol_types::SolValue::abi_decode_params(input).ok()?;
+                #[cfg(target_arch = "wasm32")]
+                if sails_rs::gstd::msg::value() > 0 {
+                    core::panic!("'abi_method' accepts no value");
+                }
+                let result = self.abi_method(addr.into());
+                let value = 0u128;
+                let output = if __encode_reply {
+                    let message_id = sails_rs::alloy_primitives::B256::new(
+                        sails_rs::gstd::Syscall::message_id().into_bytes(),
+                    );
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(
+                        &(message_id, result),
+                    )
+                } else {
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(&(result,))
+                };
+                return Some((output, value, __encode_reply));
+            }
+            _ => None,
+        }
+    }
+    pub async fn try_handle_solidity_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+}
+impl sails_rs::gstd::services::Service for SomeService {
+    type Exposure = SomeServiceExposure<Self>;
+    fn expose(self, route_idx: u8) -> Self::Exposure {
+        Self::Exposure {
+            route_idx,
+            inner: self,
+        }
+    }
+}
+mod some_service_meta {
+    use super::*;
+    const __INTERFACE_ID: sails_rs::meta::InterfaceId = {
+        let mut final_hash = sails_rs::keccak_const::Keccak256::new();
+        final_hash = final_hash
+            .update(
+                &sails_rs::hash_fn!(
+                    query AbiMethod(sails_rs::alloy_primitives::Address) ->
+                    sails_rs::alloy_primitives::B256
+                ),
+            );
+        let hash = final_hash.finalize();
+        sails_rs::meta::InterfaceId::from_bytes_32(hash)
+    };
+    impl sails_rs::meta::Identifiable for super::SomeService {
+        const INTERFACE_ID: sails_rs::meta::InterfaceId = __INTERFACE_ID;
+    }
+    impl sails_rs::meta::ServiceMeta for super::SomeService {
+        type CommandsMeta = CommandsMeta;
+        type QueriesMeta = QueriesMeta;
+        type EventsMeta = EventsMeta;
+        const BASE_SERVICES: &'static [sails_rs::meta::BaseServiceMeta] = &[];
+        const METHODS: &'static [sails_rs::meta::MethodMetadata] = &[
+            sails_rs::meta::MethodMetadata {
+                name: "AbiMethod",
+                entry_id: 0u16,
+                hash: sails_rs::hash_fn!(
+                    query AbiMethod(sails_rs::alloy_primitives::Address) ->
+                    sails_rs::alloy_primitives::B256
+                ),
+                is_async: false,
+            },
+        ];
+        const ASYNC: bool = false;
+    }
+    sails_rs::invocation_io!(
+        pub struct __AbiMethodParams { pub (super) addr :
+        sails_rs::alloy_primitives::Address, }, interface_id = __INTERFACE_ID, entry_id =
+        0u16, decode = false,
+    );
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum CommandsMeta {}
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum QueriesMeta {
+        #[annotate(ethabi)]
+        AbiMethod(__AbiMethodParams, sails_rs::alloy_primitives::B256),
+    }
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum NoEvents {}
+    pub type EventsMeta = NoEvents;
+}
+impl sails_rs::solidity::ServiceSignature for SomeService {
+    const METHODS: &'static [sails_rs::solidity::MethodExpo] = &[
+        (
+            <SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID,
+            0u16,
+            "AbiMethod",
+            <<(
+                bool,
+                sails_rs::alloy_primitives::Address,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+            <<(
+                sails_rs::alloy_primitives::B256,
+                sails_rs::alloy_primitives::B256,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+        ),
+    ];
+}

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_events.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_events.snap
@@ -63,7 +63,7 @@ impl MyServiceWithEventsExposure<MyServiceWithEvents> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -77,7 +77,11 @@ impl MyServiceWithEventsExposure<MyServiceWithEvents> {
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <my_service_with_events_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        my_service_with_events_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -99,7 +103,11 @@ impl MyServiceWithEventsExposure<MyServiceWithEvents> {
                 let result = self.this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <my_service_with_events_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        my_service_with_events_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -119,7 +127,7 @@ impl MyServiceWithEventsExposure<MyServiceWithEvents> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_dual_export.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_dual_export.snap
@@ -1,0 +1,220 @@
+---
+source: macros-tests/tests/service_insta.rs
+expression: result
+---
+pub struct SomeServiceExposure<T> {
+    route_idx: u8,
+    inner: T,
+}
+impl<T: sails_rs::meta::ServiceMeta> sails_rs::gstd::services::Exposure
+for SomeServiceExposure<T> {
+    fn interface_id() -> sails_rs::meta::InterfaceId {
+        <T as sails_rs::meta::Identifiable>::INTERFACE_ID
+    }
+    fn route_idx(&self) -> u8 {
+        self.route_idx
+    }
+    fn check_asyncness(
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+    ) -> Option<bool> {
+        if !T::ASYNC {
+            return Some(false);
+        }
+        match (interface_id, entry_id) {
+            (id, 0u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(false)
+            }
+            _ => None,
+        }
+    }
+}
+impl<T> core::ops::Deref for SomeServiceExposure<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<T> core::ops::DerefMut for SomeServiceExposure<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl SomeServiceExposure<SomeService> {
+    #[export(scale, ethabi)]
+    pub fn dual_method(&self, p1: u32) -> u32 {
+        p1
+    }
+    pub fn try_handle(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            (
+                id,
+                0u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let request: some_service_meta::__DualMethodParams = sails_rs::scale_codec::Decode::decode(
+                        &mut input,
+                    )
+                    .expect("Failed to decode params");
+                let result = self.dual_method(request.p1);
+                let value = 0u128;
+                if !sails_rs::gstd::is_empty_tuple::<u32>() {
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DualMethodParams,
+                        _,
+                        _,
+                    >(
+                        &result,
+                        self.route_idx,
+                        |encoded_result| result_handler(encoded_result, value),
+                    );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
+                }
+                return Some(());
+            }
+            _ => None,
+        }
+    }
+    pub async fn try_handle_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+    pub fn try_handle_solidity(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            (
+                id,
+                0u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let (
+                    __encode_reply,
+                    p1,
+                ): (
+                    bool,
+                    <<u32 as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::RustType,
+                ) = sails_rs::alloy_sol_types::SolValue::abi_decode_params(input).ok()?;
+                #[cfg(target_arch = "wasm32")]
+                if sails_rs::gstd::msg::value() > 0 {
+                    core::panic!("'dual_method' accepts no value");
+                }
+                let result = self.dual_method(p1.into());
+                let value = 0u128;
+                let output = if __encode_reply {
+                    let message_id = sails_rs::alloy_primitives::B256::new(
+                        sails_rs::gstd::Syscall::message_id().into_bytes(),
+                    );
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(
+                        &(message_id, result),
+                    )
+                } else {
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(&(result,))
+                };
+                return Some((output, value, __encode_reply));
+            }
+            _ => None,
+        }
+    }
+    pub async fn try_handle_solidity_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+}
+impl sails_rs::gstd::services::Service for SomeService {
+    type Exposure = SomeServiceExposure<Self>;
+    fn expose(self, route_idx: u8) -> Self::Exposure {
+        Self::Exposure {
+            route_idx,
+            inner: self,
+        }
+    }
+}
+mod some_service_meta {
+    use super::*;
+    const __INTERFACE_ID: sails_rs::meta::InterfaceId = {
+        let mut final_hash = sails_rs::keccak_const::Keccak256::new();
+        final_hash = final_hash
+            .update(&sails_rs::hash_fn!(query DualMethod(u32) -> u32));
+        let hash = final_hash.finalize();
+        sails_rs::meta::InterfaceId::from_bytes_32(hash)
+    };
+    impl sails_rs::meta::Identifiable for super::SomeService {
+        const INTERFACE_ID: sails_rs::meta::InterfaceId = __INTERFACE_ID;
+    }
+    impl sails_rs::meta::ServiceMeta for super::SomeService {
+        type CommandsMeta = CommandsMeta;
+        type QueriesMeta = QueriesMeta;
+        type EventsMeta = EventsMeta;
+        const BASE_SERVICES: &'static [sails_rs::meta::BaseServiceMeta] = &[];
+        const METHODS: &'static [sails_rs::meta::MethodMetadata] = &[
+            sails_rs::meta::MethodMetadata {
+                name: "DualMethod",
+                entry_id: 0u16,
+                hash: sails_rs::hash_fn!(query DualMethod(u32) -> u32),
+                is_async: false,
+            },
+        ];
+        const ASYNC: bool = false;
+    }
+    sails_rs::invocation_io!(
+        pub struct __DualMethodParams { pub (super) p1 : u32, }, interface_id =
+        __INTERFACE_ID, entry_id = 0u16,
+    );
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum CommandsMeta {}
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum QueriesMeta {
+        DualMethod(__DualMethodParams, u32),
+    }
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum NoEvents {}
+    pub type EventsMeta = NoEvents;
+}
+impl sails_rs::solidity::ServiceSignature for SomeService {
+    const METHODS: &'static [sails_rs::solidity::MethodExpo] = &[
+        (
+            <SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID,
+            0u16,
+            "DualMethod",
+            <<(
+                bool,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+            <<(
+                sails_rs::alloy_primitives::B256,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+        ),
+    ];
+}

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_ethabi_only.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_ethabi_only.snap
@@ -1,0 +1,195 @@
+---
+source: macros-tests/tests/service_insta.rs
+expression: result
+---
+pub struct SomeServiceExposure<T> {
+    route_idx: u8,
+    inner: T,
+}
+impl<T: sails_rs::meta::ServiceMeta> sails_rs::gstd::services::Exposure
+for SomeServiceExposure<T> {
+    fn interface_id() -> sails_rs::meta::InterfaceId {
+        <T as sails_rs::meta::Identifiable>::INTERFACE_ID
+    }
+    fn route_idx(&self) -> u8 {
+        self.route_idx
+    }
+    fn check_asyncness(
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+    ) -> Option<bool> {
+        if !T::ASYNC {
+            return Some(false);
+        }
+        match (interface_id, entry_id) {
+            (id, 0u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(false)
+            }
+            _ => None,
+        }
+    }
+}
+impl<T> core::ops::Deref for SomeServiceExposure<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<T> core::ops::DerefMut for SomeServiceExposure<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl SomeServiceExposure<SomeService> {
+    #[export(ethabi)]
+    pub fn ethabi_method(&self, p1: u32) -> u32 {
+        p1
+    }
+    pub fn try_handle(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+    pub async fn try_handle_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+    pub fn try_handle_solidity(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            (
+                id,
+                0u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let (
+                    __encode_reply,
+                    p1,
+                ): (
+                    bool,
+                    <<u32 as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::RustType,
+                ) = sails_rs::alloy_sol_types::SolValue::abi_decode_params(input).ok()?;
+                #[cfg(target_arch = "wasm32")]
+                if sails_rs::gstd::msg::value() > 0 {
+                    core::panic!("'ethabi_method' accepts no value");
+                }
+                let result = self.ethabi_method(p1.into());
+                let value = 0u128;
+                let output = if __encode_reply {
+                    let message_id = sails_rs::alloy_primitives::B256::new(
+                        sails_rs::gstd::Syscall::message_id().into_bytes(),
+                    );
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(
+                        &(message_id, result),
+                    )
+                } else {
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(&(result,))
+                };
+                return Some((output, value, __encode_reply));
+            }
+            _ => None,
+        }
+    }
+    pub async fn try_handle_solidity_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+}
+impl sails_rs::gstd::services::Service for SomeService {
+    type Exposure = SomeServiceExposure<Self>;
+    fn expose(self, route_idx: u8) -> Self::Exposure {
+        Self::Exposure {
+            route_idx,
+            inner: self,
+        }
+    }
+}
+mod some_service_meta {
+    use super::*;
+    const __INTERFACE_ID: sails_rs::meta::InterfaceId = {
+        let mut final_hash = sails_rs::keccak_const::Keccak256::new();
+        final_hash = final_hash
+            .update(&sails_rs::hash_fn!(query EthabiMethod(u32) -> u32));
+        let hash = final_hash.finalize();
+        sails_rs::meta::InterfaceId::from_bytes_32(hash)
+    };
+    impl sails_rs::meta::Identifiable for super::SomeService {
+        const INTERFACE_ID: sails_rs::meta::InterfaceId = __INTERFACE_ID;
+    }
+    impl sails_rs::meta::ServiceMeta for super::SomeService {
+        type CommandsMeta = CommandsMeta;
+        type QueriesMeta = QueriesMeta;
+        type EventsMeta = EventsMeta;
+        const BASE_SERVICES: &'static [sails_rs::meta::BaseServiceMeta] = &[];
+        const METHODS: &'static [sails_rs::meta::MethodMetadata] = &[
+            sails_rs::meta::MethodMetadata {
+                name: "EthabiMethod",
+                entry_id: 0u16,
+                hash: sails_rs::hash_fn!(query EthabiMethod(u32) -> u32),
+                is_async: false,
+            },
+        ];
+        const ASYNC: bool = false;
+    }
+    sails_rs::invocation_io!(
+        pub struct __EthabiMethodParams { pub (super) p1 : u32, }, interface_id =
+        __INTERFACE_ID, entry_id = 0u16, decode = false,
+    );
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum CommandsMeta {}
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum QueriesMeta {
+        #[annotate(ethabi)]
+        EthabiMethod(__EthabiMethodParams, u32),
+    }
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum NoEvents {}
+    pub type EventsMeta = NoEvents;
+}
+impl sails_rs::solidity::ServiceSignature for SomeService {
+    const METHODS: &'static [sails_rs::solidity::MethodExpo] = &[
+        (
+            <SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID,
+            0u16,
+            "EthabiMethod",
+            <<(
+                bool,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+            <<(
+                sails_rs::alloy_primitives::B256,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+        ),
+    ];
+}

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_ethabi_only.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_ethabi_only.snap
@@ -168,7 +168,7 @@ mod some_service_meta {
     #[derive(sails_rs::TypeInfo)]
     #[type_info(crate = sails_rs::type_info)]
     pub enum QueriesMeta {
-        #[annotate(ethabi)]
+        #[annotate(codec = "ethabi")]
         EthabiMethod(__EthabiMethodParams, u32),
     }
     #[derive(sails_rs::TypeInfo)]

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_scale_only.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_scale_only.snap
@@ -1,0 +1,177 @@
+---
+source: macros-tests/tests/service_insta.rs
+expression: result
+---
+pub struct SomeServiceExposure<T> {
+    route_idx: u8,
+    inner: T,
+}
+impl<T: sails_rs::meta::ServiceMeta> sails_rs::gstd::services::Exposure
+for SomeServiceExposure<T> {
+    fn interface_id() -> sails_rs::meta::InterfaceId {
+        <T as sails_rs::meta::Identifiable>::INTERFACE_ID
+    }
+    fn route_idx(&self) -> u8 {
+        self.route_idx
+    }
+    fn check_asyncness(
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+    ) -> Option<bool> {
+        if !T::ASYNC {
+            return Some(false);
+        }
+        match (interface_id, entry_id) {
+            (id, 0u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(false)
+            }
+            _ => None,
+        }
+    }
+}
+impl<T> core::ops::Deref for SomeServiceExposure<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<T> core::ops::DerefMut for SomeServiceExposure<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl SomeServiceExposure<SomeService> {
+    #[export(scale)]
+    pub fn scale_method(&self, p1: u32) -> u32 {
+        p1
+    }
+    pub fn try_handle(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            (
+                id,
+                0u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let request: some_service_meta::__ScaleMethodParams = sails_rs::scale_codec::Decode::decode(
+                        &mut input,
+                    )
+                    .expect("Failed to decode params");
+                let result = self.scale_method(request.p1);
+                let value = 0u128;
+                if !sails_rs::gstd::is_empty_tuple::<u32>() {
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ScaleMethodParams,
+                        _,
+                        _,
+                    >(
+                        &result,
+                        self.route_idx,
+                        |encoded_result| result_handler(encoded_result, value),
+                    );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
+                }
+                return Some(());
+            }
+            _ => None,
+        }
+    }
+    pub async fn try_handle_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+    pub fn try_handle_solidity(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+    pub async fn try_handle_solidity_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+}
+impl sails_rs::gstd::services::Service for SomeService {
+    type Exposure = SomeServiceExposure<Self>;
+    fn expose(self, route_idx: u8) -> Self::Exposure {
+        Self::Exposure {
+            route_idx,
+            inner: self,
+        }
+    }
+}
+mod some_service_meta {
+    use super::*;
+    const __INTERFACE_ID: sails_rs::meta::InterfaceId = {
+        let mut final_hash = sails_rs::keccak_const::Keccak256::new();
+        final_hash = final_hash
+            .update(&sails_rs::hash_fn!(query ScaleMethod(u32) -> u32));
+        let hash = final_hash.finalize();
+        sails_rs::meta::InterfaceId::from_bytes_32(hash)
+    };
+    impl sails_rs::meta::Identifiable for super::SomeService {
+        const INTERFACE_ID: sails_rs::meta::InterfaceId = __INTERFACE_ID;
+    }
+    impl sails_rs::meta::ServiceMeta for super::SomeService {
+        type CommandsMeta = CommandsMeta;
+        type QueriesMeta = QueriesMeta;
+        type EventsMeta = EventsMeta;
+        const BASE_SERVICES: &'static [sails_rs::meta::BaseServiceMeta] = &[];
+        const METHODS: &'static [sails_rs::meta::MethodMetadata] = &[
+            sails_rs::meta::MethodMetadata {
+                name: "ScaleMethod",
+                entry_id: 0u16,
+                hash: sails_rs::hash_fn!(query ScaleMethod(u32) -> u32),
+                is_async: false,
+            },
+        ];
+        const ASYNC: bool = false;
+    }
+    sails_rs::invocation_io!(
+        pub struct __ScaleMethodParams { pub (super) p1 : u32, }, interface_id =
+        __INTERFACE_ID, entry_id = 0u16,
+    );
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum CommandsMeta {}
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum QueriesMeta {
+        #[annotate(scale)]
+        ScaleMethod(__ScaleMethodParams, u32),
+    }
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum NoEvents {}
+    pub type EventsMeta = NoEvents;
+}
+impl sails_rs::solidity::ServiceSignature for SomeService {
+    const METHODS: &'static [sails_rs::solidity::MethodExpo] = &[];
+}

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_scale_only.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_scale_only.snap
@@ -164,7 +164,7 @@ mod some_service_meta {
     #[derive(sails_rs::TypeInfo)]
     #[type_info(crate = sails_rs::type_info)]
     pub enum QueriesMeta {
-        #[annotate(scale)]
+        #[annotate(codec = "scale")]
         ScaleMethod(__ScaleMethodParams, u32),
     }
     #[derive(sails_rs::TypeInfo)]

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_export.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_export.snap
@@ -63,7 +63,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -77,7 +77,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -97,7 +101,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -114,7 +118,11 @@ impl SomeServiceExposure<SomeService> {
                 );
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<(u32, String)>() {
-                    <some_service_meta::__DoSomethingParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoSomethingParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends.snap
@@ -88,7 +88,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -102,7 +102,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -150,7 +154,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends_and_lifetimes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends_and_lifetimes.snap
@@ -78,7 +78,7 @@ impl<'a> ExtendedWithLifetimeExposure<ExtendedWithLifetime<'a>> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -94,7 +94,11 @@ impl<'a> ExtendedWithLifetimeExposure<ExtendedWithLifetime<'a>> {
                 let result = self.extended_name();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<String>() {
-                    <extended_with_lifetime_meta::__ExtendedNameParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        extended_with_lifetime_meta::__ExtendedNameParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -118,7 +122,11 @@ impl<'a> ExtendedWithLifetimeExposure<ExtendedWithLifetime<'a>> {
                 let result = self.name();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<String>() {
-                    <extended_with_lifetime_meta::__NameParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        extended_with_lifetime_meta::__NameParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -154,7 +162,7 @@ impl<'a> ExtendedWithLifetimeExposure<ExtendedWithLifetime<'a>> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_events.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_events.snap
@@ -59,7 +59,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -76,7 +76,11 @@ where
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <my_generic_events_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        my_generic_events_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -96,7 +100,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_generics.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_generics.snap
@@ -56,7 +56,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -75,7 +75,11 @@ where
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -95,7 +99,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_methods_with_lifetimes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_methods_with_lifetimes.snap
@@ -86,7 +86,7 @@ impl ReferenceServiceExposure<ReferenceService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -100,7 +100,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.add_byte(request.byte);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<&'static [u8]>() {
-                    <reference_service_meta::__AddByteParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__AddByteParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -122,7 +126,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.baked();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<&'static str>() {
-                    <reference_service_meta::__BakedParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__BakedParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -144,7 +152,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.incr();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<&'static ReferenceCount>() {
-                    <reference_service_meta::__IncrParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__IncrParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -164,7 +176,7 @@ impl ReferenceServiceExposure<ReferenceService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -178,7 +190,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.first_byte().await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<Option<&'static u8>>() {
-                    <reference_service_meta::__FirstByteParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__FirstByteParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -200,7 +216,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.last_byte().await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<Option<&'static u8>>() {
-                    <reference_service_meta::__LastByteParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__LastByteParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_mixed_transports.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_mixed_transports.snap
@@ -1,0 +1,418 @@
+---
+source: macros-tests/tests/service_insta.rs
+expression: result
+---
+pub struct SomeServiceExposure<T> {
+    route_idx: u8,
+    inner: T,
+}
+impl<T: sails_rs::meta::ServiceMeta> sails_rs::gstd::services::Exposure
+for SomeServiceExposure<T> {
+    fn interface_id() -> sails_rs::meta::InterfaceId {
+        <T as sails_rs::meta::Identifiable>::INTERFACE_ID
+    }
+    fn route_idx(&self) -> u8 {
+        self.route_idx
+    }
+    fn check_asyncness(
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+    ) -> Option<bool> {
+        if !T::ASYNC {
+            return Some(false);
+        }
+        match (interface_id, entry_id) {
+            (id, 0u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(false)
+            }
+            (id, 1u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(false)
+            }
+            (id, 2u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(false)
+            }
+            (id, 3u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(false)
+            }
+            _ => None,
+        }
+    }
+}
+impl<T> core::ops::Deref for SomeServiceExposure<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<T> core::ops::DerefMut for SomeServiceExposure<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl SomeServiceExposure<SomeService> {
+    #[export(scale)]
+    pub fn scale_only(&self, p1: u32) -> u32 {
+        p1
+    }
+    #[export(ethabi)]
+    pub fn ethabi_only(&self, p1: u32) -> u32 {
+        p1
+    }
+    #[export(scale, ethabi)]
+    pub fn dual(&self, p1: u32) -> u32 {
+        p1
+    }
+    #[export]
+    pub fn default_both(&self, p1: u32) -> u32 {
+        p1
+    }
+    pub fn try_handle(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            (
+                id,
+                0u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let request: some_service_meta::__DefaultBothParams = sails_rs::scale_codec::Decode::decode(
+                        &mut input,
+                    )
+                    .expect("Failed to decode params");
+                let result = self.default_both(request.p1);
+                let value = 0u128;
+                if !sails_rs::gstd::is_empty_tuple::<u32>() {
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DefaultBothParams,
+                        _,
+                        _,
+                    >(
+                        &result,
+                        self.route_idx,
+                        |encoded_result| result_handler(encoded_result, value),
+                    );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
+                }
+                return Some(());
+            }
+            (
+                id,
+                1u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let request: some_service_meta::__DualParams = sails_rs::scale_codec::Decode::decode(
+                        &mut input,
+                    )
+                    .expect("Failed to decode params");
+                let result = self.dual(request.p1);
+                let value = 0u128;
+                if !sails_rs::gstd::is_empty_tuple::<u32>() {
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DualParams,
+                        _,
+                        _,
+                    >(
+                        &result,
+                        self.route_idx,
+                        |encoded_result| result_handler(encoded_result, value),
+                    );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
+                }
+                return Some(());
+            }
+            (
+                id,
+                3u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let request: some_service_meta::__ScaleOnlyParams = sails_rs::scale_codec::Decode::decode(
+                        &mut input,
+                    )
+                    .expect("Failed to decode params");
+                let result = self.scale_only(request.p1);
+                let value = 0u128;
+                if !sails_rs::gstd::is_empty_tuple::<u32>() {
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ScaleOnlyParams,
+                        _,
+                        _,
+                    >(
+                        &result,
+                        self.route_idx,
+                        |encoded_result| result_handler(encoded_result, value),
+                    );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
+                }
+                return Some(());
+            }
+            _ => None,
+        }
+    }
+    pub async fn try_handle_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+    pub fn try_handle_solidity(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            (
+                id,
+                0u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let (
+                    __encode_reply,
+                    p1,
+                ): (
+                    bool,
+                    <<u32 as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::RustType,
+                ) = sails_rs::alloy_sol_types::SolValue::abi_decode_params(input).ok()?;
+                #[cfg(target_arch = "wasm32")]
+                if sails_rs::gstd::msg::value() > 0 {
+                    core::panic!("'default_both' accepts no value");
+                }
+                let result = self.default_both(p1.into());
+                let value = 0u128;
+                let output = if __encode_reply {
+                    let message_id = sails_rs::alloy_primitives::B256::new(
+                        sails_rs::gstd::Syscall::message_id().into_bytes(),
+                    );
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(
+                        &(message_id, result),
+                    )
+                } else {
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(&(result,))
+                };
+                return Some((output, value, __encode_reply));
+            }
+            (
+                id,
+                1u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let (
+                    __encode_reply,
+                    p1,
+                ): (
+                    bool,
+                    <<u32 as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::RustType,
+                ) = sails_rs::alloy_sol_types::SolValue::abi_decode_params(input).ok()?;
+                #[cfg(target_arch = "wasm32")]
+                if sails_rs::gstd::msg::value() > 0 {
+                    core::panic!("'dual' accepts no value");
+                }
+                let result = self.dual(p1.into());
+                let value = 0u128;
+                let output = if __encode_reply {
+                    let message_id = sails_rs::alloy_primitives::B256::new(
+                        sails_rs::gstd::Syscall::message_id().into_bytes(),
+                    );
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(
+                        &(message_id, result),
+                    )
+                } else {
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(&(result,))
+                };
+                return Some((output, value, __encode_reply));
+            }
+            (
+                id,
+                2u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let (
+                    __encode_reply,
+                    p1,
+                ): (
+                    bool,
+                    <<u32 as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::RustType,
+                ) = sails_rs::alloy_sol_types::SolValue::abi_decode_params(input).ok()?;
+                #[cfg(target_arch = "wasm32")]
+                if sails_rs::gstd::msg::value() > 0 {
+                    core::panic!("'ethabi_only' accepts no value");
+                }
+                let result = self.ethabi_only(p1.into());
+                let value = 0u128;
+                let output = if __encode_reply {
+                    let message_id = sails_rs::alloy_primitives::B256::new(
+                        sails_rs::gstd::Syscall::message_id().into_bytes(),
+                    );
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(
+                        &(message_id, result),
+                    )
+                } else {
+                    sails_rs::alloy_sol_types::SolValue::abi_encode_sequence(&(result,))
+                };
+                return Some((output, value, __encode_reply));
+            }
+            _ => None,
+        }
+    }
+    pub async fn try_handle_solidity_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        input: &[u8],
+    ) -> Option<(sails_rs::Vec<u8>, u128, bool)> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            _ => None,
+        }
+    }
+}
+impl sails_rs::gstd::services::Service for SomeService {
+    type Exposure = SomeServiceExposure<Self>;
+    fn expose(self, route_idx: u8) -> Self::Exposure {
+        Self::Exposure {
+            route_idx,
+            inner: self,
+        }
+    }
+}
+mod some_service_meta {
+    use super::*;
+    const __INTERFACE_ID: sails_rs::meta::InterfaceId = {
+        let mut final_hash = sails_rs::keccak_const::Keccak256::new();
+        final_hash = final_hash
+            .update(&sails_rs::hash_fn!(query DefaultBoth(u32) -> u32));
+        final_hash = final_hash.update(&sails_rs::hash_fn!(query Dual(u32) -> u32));
+        final_hash = final_hash
+            .update(&sails_rs::hash_fn!(query EthabiOnly(u32) -> u32));
+        final_hash = final_hash.update(&sails_rs::hash_fn!(query ScaleOnly(u32) -> u32));
+        let hash = final_hash.finalize();
+        sails_rs::meta::InterfaceId::from_bytes_32(hash)
+    };
+    impl sails_rs::meta::Identifiable for super::SomeService {
+        const INTERFACE_ID: sails_rs::meta::InterfaceId = __INTERFACE_ID;
+    }
+    impl sails_rs::meta::ServiceMeta for super::SomeService {
+        type CommandsMeta = CommandsMeta;
+        type QueriesMeta = QueriesMeta;
+        type EventsMeta = EventsMeta;
+        const BASE_SERVICES: &'static [sails_rs::meta::BaseServiceMeta] = &[];
+        const METHODS: &'static [sails_rs::meta::MethodMetadata] = &[
+            sails_rs::meta::MethodMetadata {
+                name: "DefaultBoth",
+                entry_id: 0u16,
+                hash: sails_rs::hash_fn!(query DefaultBoth(u32) -> u32),
+                is_async: false,
+            },
+            sails_rs::meta::MethodMetadata {
+                name: "Dual",
+                entry_id: 1u16,
+                hash: sails_rs::hash_fn!(query Dual(u32) -> u32),
+                is_async: false,
+            },
+            sails_rs::meta::MethodMetadata {
+                name: "EthabiOnly",
+                entry_id: 2u16,
+                hash: sails_rs::hash_fn!(query EthabiOnly(u32) -> u32),
+                is_async: false,
+            },
+            sails_rs::meta::MethodMetadata {
+                name: "ScaleOnly",
+                entry_id: 3u16,
+                hash: sails_rs::hash_fn!(query ScaleOnly(u32) -> u32),
+                is_async: false,
+            },
+        ];
+        const ASYNC: bool = false;
+    }
+    sails_rs::invocation_io!(
+        pub struct __DefaultBothParams { pub (super) p1 : u32, }, interface_id =
+        __INTERFACE_ID, entry_id = 0u16,
+    );
+    sails_rs::invocation_io!(
+        pub struct __DualParams { pub (super) p1 : u32, }, interface_id = __INTERFACE_ID,
+        entry_id = 1u16,
+    );
+    sails_rs::invocation_io!(
+        pub struct __EthabiOnlyParams { pub (super) p1 : u32, }, interface_id =
+        __INTERFACE_ID, entry_id = 2u16, decode = false,
+    );
+    sails_rs::invocation_io!(
+        pub struct __ScaleOnlyParams { pub (super) p1 : u32, }, interface_id =
+        __INTERFACE_ID, entry_id = 3u16,
+    );
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum CommandsMeta {}
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum QueriesMeta {
+        DefaultBoth(__DefaultBothParams, u32),
+        Dual(__DualParams, u32),
+        #[annotate(ethabi)]
+        EthabiOnly(__EthabiOnlyParams, u32),
+        #[annotate(scale)]
+        ScaleOnly(__ScaleOnlyParams, u32),
+    }
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum NoEvents {}
+    pub type EventsMeta = NoEvents;
+}
+impl sails_rs::solidity::ServiceSignature for SomeService {
+    const METHODS: &'static [sails_rs::solidity::MethodExpo] = &[
+        (
+            <SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID,
+            0u16,
+            "DefaultBoth",
+            <<(
+                bool,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+            <<(
+                sails_rs::alloy_primitives::B256,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+        ),
+        (
+            <SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID,
+            1u16,
+            "Dual",
+            <<(
+                bool,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+            <<(
+                sails_rs::alloy_primitives::B256,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+        ),
+        (
+            <SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID,
+            2u16,
+            "EthabiOnly",
+            <<(
+                bool,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+            <<(
+                sails_rs::alloy_primitives::B256,
+                u32,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+        ),
+    ];
+}

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_mixed_transports.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_mixed_transports.snap
@@ -363,9 +363,9 @@ mod some_service_meta {
     pub enum QueriesMeta {
         DefaultBoth(__DefaultBothParams, u32),
         Dual(__DualParams, u32),
-        #[annotate(ethabi)]
+        #[annotate(codec = "ethabi")]
         EthabiOnly(__EthabiOnlyParams, u32),
-        #[annotate(scale)]
+        #[annotate(codec = "scale")]
         ScaleOnly(__ScaleOnlyParams, u32),
     }
     #[derive(sails_rs::TypeInfo)]

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
@@ -59,7 +59,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -73,7 +73,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -93,7 +97,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -110,7 +114,11 @@ impl SomeServiceExposure<SomeService> {
                     .into();
                 let (result, value) = command_reply.to_tuple();
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_special_lifetimes_and_events.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_special_lifetimes_and_events.snap
@@ -59,7 +59,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -77,7 +77,11 @@ where
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <my_generic_events_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        my_generic_events_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -97,7 +101,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_duplicate_ethabi.rs
+++ b/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_duplicate_ethabi.rs
@@ -1,0 +1,13 @@
+use sails_rs::prelude::*;
+
+struct SomeService;
+
+#[sails_rs::service]
+impl SomeService {
+    #[export(ethabi, ethabi)]
+    pub fn do_this(&self) -> u32 {
+        42
+    }
+}
+
+fn main() {}

--- a/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_duplicate_ethabi.stderr
+++ b/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_duplicate_ethabi.stderr
@@ -1,0 +1,5 @@
+error: `export` attribute cannot be parsed: duplicate `ethabi` flag in `#[export]`
+ --> tests/ui/validation_gservice_fails_export_duplicate_ethabi.rs:7:7
+  |
+7 |     #[export(ethabi, ethabi)]
+  |       ^^^^^^

--- a/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_duplicate_ethabi.stderr
+++ b/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_duplicate_ethabi.stderr
@@ -1,5 +1,5 @@
 error: `export` attribute cannot be parsed: duplicate `ethabi` flag in `#[export]`
- --> tests/ui/validation_gservice_fails_export_duplicate_ethabi.rs:7:7
+ --> tests/ui/validation_gservice_fails_export_duplicate_ethabi.rs:7:22
   |
 7 |     #[export(ethabi, ethabi)]
-  |       ^^^^^^
+  |                      ^^^^^^

--- a/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_payable_without_ethabi.rs
+++ b/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_payable_without_ethabi.rs
@@ -1,0 +1,13 @@
+use sails_rs::prelude::*;
+
+struct SomeService;
+
+#[sails_rs::service]
+impl SomeService {
+    #[export(scale, payable)]
+    pub fn do_this(&self) -> u32 {
+        42
+    }
+}
+
+fn main() {}

--- a/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_payable_without_ethabi.stderr
+++ b/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_payable_without_ethabi.stderr
@@ -1,0 +1,5 @@
+error: `export` attribute cannot be parsed: `payable` requires `ethabi` transport; write `#[export(ethabi, payable)]` or `#[export(scale, ethabi, payable)]`
+ --> tests/ui/validation_gservice_fails_export_payable_without_ethabi.rs:7:7
+  |
+7 |     #[export(scale, payable)]
+  |       ^^^^^^

--- a/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_payable_without_ethabi.stderr
+++ b/rs/ethexe/macros-tests/tests/ui/validation_gservice_fails_export_payable_without_ethabi.stderr
@@ -1,5 +1,5 @@
 error: `export` attribute cannot be parsed: `payable` requires `ethabi` transport; write `#[export(ethabi, payable)]` or `#[export(scale, ethabi, payable)]`
- --> tests/ui/validation_gservice_fails_export_payable_without_ethabi.rs:7:7
+ --> tests/ui/validation_gservice_fails_export_payable_without_ethabi.rs:7:21
   |
 7 |     #[export(scale, payable)]
-  |       ^^^^^^
+  |                     ^^^^^^^

--- a/rs/ethexe/macros-tests/tests/ui/validation_passes_ethabi_only_non_scale_type.rs
+++ b/rs/ethexe/macros-tests/tests/ui/validation_passes_ethabi_only_non_scale_type.rs
@@ -1,0 +1,16 @@
+use sails_rs::prelude::*;
+
+struct SomeService;
+
+#[sails_rs::service]
+impl SomeService {
+    #[export(ethabi)]
+    pub fn abi_method(
+        &self,
+        _addr: sails_rs::alloy_primitives::Address,
+    ) -> sails_rs::alloy_primitives::B256 {
+        sails_rs::alloy_primitives::B256::ZERO
+    }
+}
+
+fn main() {}

--- a/rs/ethexe/macros-tests/tests/validation_tests.rs
+++ b/rs/ethexe/macros-tests/tests/validation_tests.rs
@@ -6,10 +6,5 @@ fn validation_tests() {
     t.compile_fail("tests/ui/validation_gprogram_fails_for_solidity_reserved_name.rs");
     t.compile_fail("tests/ui/validation_gprogram_fails_for_service_constructor_reserved_name.rs");
     t.pass("tests/ui/validation_passes_for_non_exported_name.rs");
-}
-
-#[test]
-fn ethabi_only_non_scale_type_passes() {
-    let t = trybuild::TestCases::new();
     t.pass("tests/ui/validation_passes_ethabi_only_non_scale_type.rs");
 }

--- a/rs/ethexe/macros-tests/tests/validation_tests.rs
+++ b/rs/ethexe/macros-tests/tests/validation_tests.rs
@@ -1,7 +1,15 @@
 #[test]
 fn validation_tests() {
     let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/validation_gservice_fails_export_duplicate_ethabi.rs");
+    t.compile_fail("tests/ui/validation_gservice_fails_export_payable_without_ethabi.rs");
     t.compile_fail("tests/ui/validation_gprogram_fails_for_solidity_reserved_name.rs");
     t.compile_fail("tests/ui/validation_gprogram_fails_for_service_constructor_reserved_name.rs");
     t.pass("tests/ui/validation_passes_for_non_exported_name.rs");
+}
+
+#[test]
+fn ethabi_only_non_scale_type_passes() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/validation_passes_ethabi_only_non_scale_type.rs");
 }

--- a/rs/idl-parser-v2/src/lib.rs
+++ b/rs/idl-parser-v2/src/lib.rs
@@ -82,12 +82,11 @@ fn build_idl(top: Pair<Rule>) -> Result<IdlDoc> {
                 globals.push(parse_annotation(p)?);
             }
             Rule::ServiceDecl => services.push(parse_service(p)?),
-            Rule::ProgramDecl
-                if program.replace(parse_program(p)?).is_some() => {
-                    return Err(Error::Validation(
-                        "expected at most one program per IDL document".to_string(),
-                    ));
-                }
+            Rule::ProgramDecl if program.replace(parse_program(p)?).is_some() => {
+                return Err(Error::Validation(
+                    "expected at most one program per IDL document".to_string(),
+                ));
+            }
             _ => {}
         }
     }

--- a/rs/idl-parser-v2/src/lib.rs
+++ b/rs/idl-parser-v2/src/lib.rs
@@ -82,13 +82,12 @@ fn build_idl(top: Pair<Rule>) -> Result<IdlDoc> {
                 globals.push(parse_annotation(p)?);
             }
             Rule::ServiceDecl => services.push(parse_service(p)?),
-            Rule::ProgramDecl => {
-                if program.replace(parse_program(p)?).is_some() {
+            Rule::ProgramDecl
+                if program.replace(parse_program(p)?).is_some() => {
                     return Err(Error::Validation(
                         "expected at most one program per IDL document".to_string(),
                     ));
                 }
-            }
             _ => {}
         }
     }

--- a/rs/macros/core/src/export/args.rs
+++ b/rs/macros/core/src/export/args.rs
@@ -5,7 +5,7 @@ use syn::{
     punctuated::Punctuated,
 };
 
-#[derive(PartialEq, Debug, Default)]
+#[derive(PartialEq, Debug)]
 pub(crate) struct ExportArgs {
     route: Option<String>,
     unwrap_result: bool,
@@ -13,6 +13,25 @@ pub(crate) struct ExportArgs {
     payable: bool,
     overrides: Option<Path>,
     entry_id: Option<u16>,
+    scale: bool,
+    #[cfg(feature = "ethexe")]
+    ethabi: bool,
+}
+
+impl Default for ExportArgs {
+    fn default() -> Self {
+        Self {
+            route: None,
+            unwrap_result: false,
+            #[cfg(feature = "ethexe")]
+            payable: false,
+            overrides: None,
+            entry_id: None,
+            scale: true,
+            #[cfg(feature = "ethexe")]
+            ethabi: true,
+        }
+    }
 }
 
 impl ExportArgs {
@@ -36,6 +55,15 @@ impl ExportArgs {
     pub fn entry_id(&self) -> Option<u16> {
         self.entry_id
     }
+
+    pub fn scale(&self) -> bool {
+        self.scale
+    }
+
+    #[cfg(feature = "ethexe")]
+    pub fn ethabi(&self) -> bool {
+        self.ethabi
+    }
 }
 
 impl Parse for ExportArgs {
@@ -48,7 +76,17 @@ impl Parse for ExportArgs {
             payable: false,
             overrides: None,
             entry_id: None,
+            scale: false,
+            #[cfg(feature = "ethexe")]
+            ethabi: false,
         };
+        let mut any_transport_flag_seen = false;
+        let mut scale_seen = false;
+        #[cfg(feature = "ethexe")]
+        let mut ethabi_seen = false;
+        #[cfg(feature = "ethexe")]
+        let mut payable_span: Option<proc_macro2::Span> = None;
+
         for arg in punctuated {
             match arg {
                 ImportArg::Route(route) => {
@@ -58,8 +96,9 @@ impl Parse for ExportArgs {
                     args.unwrap_result = unwrap_result;
                 }
                 #[cfg(feature = "ethexe")]
-                ImportArg::Payable => {
+                ImportArg::Payable(span) => {
                     args.payable = true;
+                    payable_span = Some(span);
                 }
                 ImportArg::Overrides(path) => {
                     args.overrides = Some(path);
@@ -67,8 +106,50 @@ impl Parse for ExportArgs {
                 ImportArg::EntryId(entry_id) => {
                     args.entry_id = Some(entry_id);
                 }
+                ImportArg::Scale(span) => {
+                    if scale_seen {
+                        return Err(syn::Error::new(
+                            span,
+                            "duplicate `scale` flag in `#[export]`",
+                        ));
+                    }
+                    scale_seen = true;
+                    any_transport_flag_seen = true;
+                    args.scale = true;
+                }
+                #[cfg(feature = "ethexe")]
+                ImportArg::Ethabi(span) => {
+                    if ethabi_seen {
+                        return Err(syn::Error::new(
+                            span,
+                            "duplicate `ethabi` flag in `#[export]`",
+                        ));
+                    }
+                    ethabi_seen = true;
+                    any_transport_flag_seen = true;
+                    args.ethabi = true;
+                }
             }
         }
+
+        if !any_transport_flag_seen {
+            args.scale = true;
+            #[cfg(feature = "ethexe")]
+            {
+                args.ethabi = true;
+            }
+        }
+
+        #[cfg(feature = "ethexe")]
+        if let Some(span) = payable_span
+            && !args.ethabi
+        {
+            return Err(syn::Error::new(
+                span,
+                "`payable` requires `ethabi` transport; write `#[export(ethabi, payable)]` or `#[export(scale, ethabi, payable)]`",
+            ));
+        }
+
         Ok(args)
     }
 }
@@ -78,15 +159,19 @@ enum ImportArg {
     Route(String),
     UnwrapResult(bool),
     #[cfg(feature = "ethexe")]
-    Payable,
+    Payable(proc_macro2::Span),
     Overrides(Path),
     EntryId(u16),
+    Scale(proc_macro2::Span),
+    #[cfg(feature = "ethexe")]
+    Ethabi(proc_macro2::Span),
 }
 
 impl Parse for ImportArg {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let path = input.parse::<Path>()?;
         let ident = path.get_ident().unwrap();
+        let ident_span = ident.span();
         match ident.to_string().as_str() {
             "route" => {
                 input.parse::<Token![=]>()?;
@@ -112,7 +197,7 @@ impl Parse for ImportArg {
                 Ok(Self::UnwrapResult(true))
             }
             #[cfg(feature = "ethexe")]
-            "payable" => Ok(Self::Payable),
+            "payable" => Ok(Self::Payable(ident_span)),
             "overrides" => {
                 input.parse::<Token![=]>()?;
                 let path = input.parse::<Path>()?;
@@ -124,6 +209,9 @@ impl Parse for ImportArg {
                 let entry_id = lit.base10_parse::<u16>()?;
                 Ok(Self::EntryId(entry_id))
             }
+            "scale" => Ok(Self::Scale(ident_span)),
+            #[cfg(feature = "ethexe")]
+            "ethabi" => Ok(Self::Ethabi(ident_span)),
             _ => abort!(ident, "unknown argument: {}", ident),
         }
     }
@@ -145,6 +233,9 @@ mod tests {
             payable: false,
             overrides: None,
             entry_id: None,
+            scale: true,
+            #[cfg(feature = "ethexe")]
+            ethabi: true,
         };
 
         // act
@@ -165,6 +256,9 @@ mod tests {
             payable: false,
             overrides: None,
             entry_id: None,
+            scale: true,
+            #[cfg(feature = "ethexe")]
+            ethabi: true,
         };
 
         // act
@@ -185,6 +279,9 @@ mod tests {
             payable: false,
             overrides: None,
             entry_id: None,
+            scale: true,
+            #[cfg(feature = "ethexe")]
+            ethabi: true,
         };
 
         // act
@@ -205,6 +302,8 @@ mod tests {
             payable: true,
             overrides: None,
             entry_id: None,
+            scale: true,
+            ethabi: true,
         };
 
         // act
@@ -226,6 +325,9 @@ mod tests {
             payable: false,
             overrides: Some(expected_path),
             entry_id: Some(42),
+            scale: true,
+            #[cfg(feature = "ethexe")]
+            ethabi: true,
         };
 
         // act
@@ -233,5 +335,96 @@ mod tests {
 
         // arrange
         assert_eq!(expected, args);
+    }
+
+    #[test]
+    fn export_parse_args_scale_only() {
+        let input = quote!(scale);
+        let args = syn::parse2::<ExportArgs>(input).unwrap();
+
+        assert!(args.scale());
+        #[cfg(feature = "ethexe")]
+        assert!(!args.ethabi());
+    }
+
+    #[cfg(feature = "ethexe")]
+    #[test]
+    fn export_parse_args_ethabi_only() {
+        let input = quote!(ethabi);
+        let args = syn::parse2::<ExportArgs>(input).unwrap();
+
+        assert!(!args.scale());
+        assert!(args.ethabi());
+    }
+
+    #[cfg(feature = "ethexe")]
+    #[test]
+    fn export_parse_args_scale_and_ethabi() {
+        let input = quote!(scale, ethabi);
+        let args = syn::parse2::<ExportArgs>(input).unwrap();
+
+        assert!(args.scale());
+        assert!(args.ethabi());
+    }
+
+    #[test]
+    fn export_parse_args_default_is_both() {
+        let input = quote!();
+        let args = syn::parse2::<ExportArgs>(input).unwrap();
+
+        assert!(args.scale());
+        #[cfg(feature = "ethexe")]
+        assert!(args.ethabi());
+    }
+
+    #[test]
+    fn export_parse_args_duplicate_scale_errors() {
+        let input = quote!(scale, scale);
+        let err = syn::parse2::<ExportArgs>(input).unwrap_err();
+
+        assert!(err.to_string().contains("duplicate `scale` flag"));
+    }
+
+    #[cfg(feature = "ethexe")]
+    #[test]
+    fn export_parse_args_duplicate_ethabi_errors() {
+        let input = quote!(ethabi, ethabi);
+        let err = syn::parse2::<ExportArgs>(input).unwrap_err();
+
+        assert!(err.to_string().contains("duplicate `ethabi` flag"));
+    }
+
+    #[cfg(feature = "ethexe")]
+    #[test]
+    fn export_parse_args_payable_requires_ethabi() {
+        let input = quote!(scale, payable);
+        let err = syn::parse2::<ExportArgs>(input).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("`payable` requires `ethabi` transport")
+        );
+    }
+
+    #[cfg(feature = "ethexe")]
+    #[test]
+    fn export_parse_args_payable_with_ethabi_ok() {
+        let input = quote!(ethabi, payable);
+        let args = syn::parse2::<ExportArgs>(input).unwrap();
+
+        assert!(!args.scale());
+        assert!(args.ethabi());
+        assert!(args.payable());
+    }
+
+    #[cfg(feature = "ethexe")]
+    #[test]
+    fn export_parse_args_plain_payable_ok_under_ethexe() {
+        let input = quote!(payable);
+        let args = syn::parse2::<ExportArgs>(input).unwrap();
+
+        assert!(args.scale());
+        assert!(args.ethabi());
+        assert!(args.payable());
     }
 }

--- a/rs/macros/core/src/export/mod.rs
+++ b/rs/macros/core/src/export/mod.rs
@@ -80,7 +80,7 @@ pub(crate) fn parse_attr(attr: &Attribute) -> Option<ExportArgs> {
             let args = list
                 .parse_args_with(ExportArgs::parse)
                 .unwrap_or_else(|err| {
-                    abort!(list.span(), "`export` attribute cannot be parsed: {}", err)
+                    abort!(err.span(), "`export` attribute cannot be parsed: {}", err)
                 });
             Some(args)
         } else {

--- a/rs/macros/core/src/service/ethexe.rs
+++ b/rs/macros/core/src/service/ethexe.rs
@@ -11,6 +11,7 @@ impl ServiceBuilder<'_> {
         let service_method_expo = self
             .service_handlers
             .iter()
+            .filter(|fn_builder| fn_builder.has_ethabi_transport())
             .map(|fn_builder| fn_builder.sol_handler_signature(Some(service_type_path)));
 
         let combined_methods = if self.base_types.is_empty() {
@@ -75,6 +76,7 @@ impl ServiceBuilder<'_> {
                 method_sig: &method_sig,
                 extra_imports: &extra_imports,
                 metadata_type: &metadata_type,
+                transport: Transport::Ethabi,
             };
 
             self.generate_dispatch_impl(

--- a/rs/macros/core/src/service/ethexe.rs
+++ b/rs/macros/core/src/service/ethexe.rs
@@ -11,7 +11,7 @@ impl ServiceBuilder<'_> {
         let service_method_expo = self
             .service_handlers
             .iter()
-            .filter(|fn_builder| fn_builder.has_ethabi_transport())
+            .filter(|fn_builder| fn_builder.has_ethabi_codec())
             .map(|fn_builder| fn_builder.sol_handler_signature(Some(service_type_path)));
 
         let combined_methods = if self.base_types.is_empty() {
@@ -76,7 +76,7 @@ impl ServiceBuilder<'_> {
                 method_sig: &method_sig,
                 extra_imports: &extra_imports,
                 metadata_type: &metadata_type,
-                transport: Transport::Ethabi,
+                codec: Codec::Ethabi,
             };
 
             self.generate_dispatch_impl(

--- a/rs/macros/core/src/service/exposure.rs
+++ b/rs/macros/core/src/service/exposure.rs
@@ -148,7 +148,7 @@ impl ServiceBuilder<'_> {
             method_sig,
             extra_imports,
             metadata_type,
-            transport,
+            codec,
         } = params;
 
         let (async_kw, await_token) = if is_async {
@@ -164,12 +164,12 @@ impl ServiceBuilder<'_> {
                 continue;
             }
 
-            let transport_ok = match transport {
-                Transport::Scale => fn_builder.has_scale_transport(),
+            let codec_ok = match codec {
+                Codec::Scale => fn_builder.has_scale_codec(),
                 #[cfg(feature = "ethexe")]
-                Transport::Ethabi => fn_builder.has_ethabi_transport(),
+                Codec::Ethabi => fn_builder.has_ethabi_codec(),
             };
-            if !transport_ok {
+            if !codec_ok {
                 continue;
             }
 
@@ -268,7 +268,7 @@ impl ServiceBuilder<'_> {
             method_sig: &method_sig,
             extra_imports: &extra_imports,
             metadata_type: &metadata_type,
-            transport: Transport::Scale,
+            codec: Codec::Scale,
         };
 
         self.generate_dispatch_impl(

--- a/rs/macros/core/src/service/exposure.rs
+++ b/rs/macros/core/src/service/exposure.rs
@@ -122,7 +122,7 @@ impl ServiceBuilder<'_> {
                 .expect("Failed to decode params");
             #handle_token
             if ! #sails_path::gstd::is_empty_tuple::<#result_type_static>() {
-                <#meta_module_ident::#params_struct_ident as #sails_path::gstd::InvocationIo>::with_optimized_encode(
+                #sails_path::gstd::encode_invocation_payload::<#meta_module_ident::#params_struct_ident, _, _>(
                     &result,
                     self.route_idx,
                     |encoded_result| result_handler(encoded_result, value),
@@ -148,6 +148,7 @@ impl ServiceBuilder<'_> {
             method_sig,
             extra_imports,
             metadata_type,
+            transport,
         } = params;
 
         let (async_kw, await_token) = if is_async {
@@ -160,6 +161,15 @@ impl ServiceBuilder<'_> {
 
         for fn_builder in &self.service_handlers {
             if is_async != fn_builder.is_async() {
+                continue;
+            }
+
+            let transport_ok = match transport {
+                Transport::Scale => fn_builder.has_scale_transport(),
+                #[cfg(feature = "ethexe")]
+                Transport::Ethabi => fn_builder.has_ethabi_transport(),
+            };
+            if !transport_ok {
                 continue;
             }
 
@@ -247,7 +257,7 @@ impl ServiceBuilder<'_> {
         };
 
         let extra_imports = quote! {
-            use #sails_path::gstd::{InvocationIo, CommandReply};
+            use #sails_path::gstd::CommandReply;
         };
 
         let metadata_type = quote!(self::#service_type_path);
@@ -258,6 +268,7 @@ impl ServiceBuilder<'_> {
             method_sig: &method_sig,
             extra_imports: &extra_imports,
             metadata_type: &metadata_type,
+            transport: Transport::Scale,
         };
 
         self.generate_dispatch_impl(

--- a/rs/macros/core/src/service/mod.rs
+++ b/rs/macros/core/src/service/mod.rs
@@ -237,12 +237,23 @@ impl FnBuilder<'_> {
             None
         };
 
+        #[cfg(feature = "ethexe")]
+        let transport_ann: Option<TokenStream> =
+            match (self.has_scale_transport(), self.has_ethabi_transport()) {
+                (true, false) => Some(quote!(#[annotate(scale)])),
+                (false, true) => Some(quote!(#[annotate(ethabi)])),
+                _ => None,
+            };
+        #[cfg(not(feature = "ethexe"))]
+        let transport_ann: Option<TokenStream> = None;
+
         if let Some(err_ty) = &self.error_type {
             let err_ty = shared::replace_any_lifetime_with_static(err_ty.clone());
             quote!(
                 #( #handler_docs_attrs )*
                 #payable_ann
                 #returns_value_ann
+                #transport_ann
                 #handler_route_ident(#params_struct_ident, #result_type, #err_ty)
             )
         } else {
@@ -250,6 +261,7 @@ impl FnBuilder<'_> {
                 #( #handler_docs_attrs )*
                 #payable_ann
                 #returns_value_ann
+                #transport_ann
                 #handler_route_ident(#params_struct_ident, #result_type)
             )
         }

--- a/rs/macros/core/src/service/mod.rs
+++ b/rs/macros/core/src/service/mod.rs
@@ -299,6 +299,8 @@ impl FnBuilder<'_> {
             (quote! { #own_interface_id }, quote! { #entry_id })
         };
 
+        let decode_disabled = (!self.has_scale_transport()).then(|| quote!(decode = false,));
+
         quote!(
             #sails_path::invocation_io!(
                 pub struct #params_struct_ident {
@@ -306,6 +308,7 @@ impl FnBuilder<'_> {
                 },
                 interface_id = #interface_id_computation,
                 entry_id = #entry_id_computation,
+                #decode_disabled
             );
         )
     }

--- a/rs/macros/core/src/service/mod.rs
+++ b/rs/macros/core/src/service/mod.rs
@@ -71,12 +71,20 @@ struct ServiceBuilder<'a> {
     meta_module_ident: Ident,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum Transport {
+    Scale,
+    #[cfg(feature = "ethexe")]
+    Ethabi,
+}
+
 struct DispatchParams<'a> {
     is_async: bool,
     method_name_ident: &'a Ident,
     method_sig: &'a TokenStream,
     extra_imports: &'a TokenStream,
     metadata_type: &'a TokenStream,
+    transport: Transport,
 }
 
 impl<'a> ServiceBuilder<'a> {

--- a/rs/macros/core/src/service/mod.rs
+++ b/rs/macros/core/src/service/mod.rs
@@ -72,7 +72,7 @@ struct ServiceBuilder<'a> {
 }
 
 #[derive(Clone, Copy)]
-pub(crate) enum Transport {
+pub(crate) enum Codec {
     Scale,
     #[cfg(feature = "ethexe")]
     Ethabi,
@@ -84,7 +84,7 @@ struct DispatchParams<'a> {
     method_sig: &'a TokenStream,
     extra_imports: &'a TokenStream,
     metadata_type: &'a TokenStream,
-    transport: Transport,
+    codec: Codec,
 }
 
 impl<'a> ServiceBuilder<'a> {
@@ -238,14 +238,14 @@ impl FnBuilder<'_> {
         };
 
         #[cfg(feature = "ethexe")]
-        let transport_ann: Option<TokenStream> =
-            match (self.has_scale_transport(), self.has_ethabi_transport()) {
-                (true, false) => Some(quote!(#[annotate(scale)])),
-                (false, true) => Some(quote!(#[annotate(ethabi)])),
-                _ => None,
-            };
+        let codec_ann: Option<TokenStream> = match (self.has_scale_codec(), self.has_ethabi_codec())
+        {
+            (true, false) => Some(quote!(#[annotate(codec = "scale")])),
+            (false, true) => Some(quote!(#[annotate(codec = "ethabi")])),
+            _ => None,
+        };
         #[cfg(not(feature = "ethexe"))]
-        let transport_ann: Option<TokenStream> = None;
+        let codec_ann: Option<TokenStream> = None;
 
         if let Some(err_ty) = &self.error_type {
             let err_ty = shared::replace_any_lifetime_with_static(err_ty.clone());
@@ -253,7 +253,7 @@ impl FnBuilder<'_> {
                 #( #handler_docs_attrs )*
                 #payable_ann
                 #returns_value_ann
-                #transport_ann
+                #codec_ann
                 #handler_route_ident(#params_struct_ident, #result_type, #err_ty)
             )
         } else {
@@ -261,7 +261,7 @@ impl FnBuilder<'_> {
                 #( #handler_docs_attrs )*
                 #payable_ann
                 #returns_value_ann
-                #transport_ann
+                #codec_ann
                 #handler_route_ident(#params_struct_ident, #result_type)
             )
         }
@@ -299,7 +299,7 @@ impl FnBuilder<'_> {
             (quote! { #own_interface_id }, quote! { #entry_id })
         };
 
-        let decode_disabled = (!self.has_scale_transport()).then(|| quote!(decode = false,));
+        let decode_disabled = (!self.has_scale_codec()).then(|| quote!(decode = false,));
 
         quote!(
             #sails_path::invocation_io!(

--- a/rs/macros/core/src/shared.rs
+++ b/rs/macros/core/src/shared.rs
@@ -320,10 +320,8 @@ pub(crate) struct FnBuilder<'a> {
     pub result_type: Type,
     pub error_type: Option<Type>,
     pub sails_path: &'a Path,
-    #[allow(dead_code)]
     pub scale: bool,
     #[cfg(feature = "ethexe")]
-    #[allow(dead_code)]
     pub ethabi: bool,
 }
 
@@ -392,13 +390,11 @@ impl<'a> FnBuilder<'a> {
             .is_none_or(|r| r.mutability.is_none())
     }
 
-    #[allow(dead_code)]
     pub(crate) fn has_scale_transport(&self) -> bool {
         self.scale
     }
 
     #[cfg(feature = "ethexe")]
-    #[allow(dead_code)]
     pub(crate) fn has_ethabi_transport(&self) -> bool {
         self.ethabi
     }

--- a/rs/macros/core/src/shared.rs
+++ b/rs/macros/core/src/shared.rs
@@ -390,18 +390,18 @@ impl<'a> FnBuilder<'a> {
             .is_none_or(|r| r.mutability.is_none())
     }
 
-    pub(crate) fn has_scale_transport(&self) -> bool {
+    pub(crate) fn has_scale_codec(&self) -> bool {
         self.scale
     }
 
     #[cfg(feature = "ethexe")]
-    pub(crate) fn has_ethabi_transport(&self) -> bool {
+    pub(crate) fn has_ethabi_codec(&self) -> bool {
         self.ethabi
     }
 
     #[cfg(not(feature = "ethexe"))]
     #[allow(dead_code)]
-    pub(crate) fn has_ethabi_transport(&self) -> bool {
+    pub(crate) fn has_ethabi_codec(&self) -> bool {
         false
     }
 

--- a/rs/macros/core/src/shared.rs
+++ b/rs/macros/core/src/shared.rs
@@ -86,14 +86,20 @@ pub(crate) struct InvocationExport {
     pub payable: bool,
     pub overrides: Option<Path>,
     pub entry_id: Option<u16>,
+    pub scale: bool,
+    #[cfg(feature = "ethexe")]
+    pub ethabi: bool,
 }
 
 pub(crate) fn invocation_export(fn_impl: &ImplItemFn) -> Option<InvocationExport> {
     export::parse_export_args(&fn_impl.attrs).map(|(args, span)| {
         let ident = &fn_impl.sig.ident;
         let unwrap_result = args.unwrap_result();
+        let scale = args.scale();
         #[cfg(feature = "ethexe")]
         let payable = args.payable();
+        #[cfg(feature = "ethexe")]
+        let ethabi = args.ethabi();
 
         let route = args.route().map_or_else(
             || ident.to_string().to_case(Case::Pascal),
@@ -108,6 +114,9 @@ pub(crate) fn invocation_export(fn_impl: &ImplItemFn) -> Option<InvocationExport
             payable,
             overrides: args.overrides().cloned(),
             entry_id: args.entry_id(),
+            scale,
+            #[cfg(feature = "ethexe")]
+            ethabi,
         }
     })
 }
@@ -124,6 +133,9 @@ pub(crate) fn invocation_export_or_default(fn_impl: &ImplItemFn) -> InvocationEx
             payable: false,
             overrides: None,
             entry_id: None,
+            scale: true,
+            #[cfg(feature = "ethexe")]
+            ethabi: true,
         }
     })
 }
@@ -308,6 +320,11 @@ pub(crate) struct FnBuilder<'a> {
     pub result_type: Type,
     pub error_type: Option<Type>,
     pub sails_path: &'a Path,
+    #[allow(dead_code)]
+    pub scale: bool,
+    #[cfg(feature = "ethexe")]
+    #[allow(dead_code)]
+    pub ethabi: bool,
 }
 
 impl<'a> FnBuilder<'a> {
@@ -325,6 +342,9 @@ impl<'a> FnBuilder<'a> {
             payable,
             overrides,
             entry_id: override_entry_id,
+            scale,
+            #[cfg(feature = "ethexe")]
+            ethabi,
             ..
         } = ie;
         let signature = &impl_fn.sig;
@@ -355,6 +375,9 @@ impl<'a> FnBuilder<'a> {
             result_type,
             error_type,
             sails_path,
+            scale,
+            #[cfg(feature = "ethexe")]
+            ethabi,
         }
     }
 
@@ -367,6 +390,23 @@ impl<'a> FnBuilder<'a> {
             .sig
             .receiver()
             .is_none_or(|r| r.mutability.is_none())
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn has_scale_transport(&self) -> bool {
+        self.scale
+    }
+
+    #[cfg(feature = "ethexe")]
+    #[allow(dead_code)]
+    pub(crate) fn has_ethabi_transport(&self) -> bool {
+        self.ethabi
+    }
+
+    #[cfg(not(feature = "ethexe"))]
+    #[allow(dead_code)]
+    pub(crate) fn has_ethabi_transport(&self) -> bool {
+        false
     }
 
     pub(crate) fn result_type_with_value(&self) -> (&Type, bool) {

--- a/rs/macros/core/tests/gservice.rs
+++ b/rs/macros/core/tests/gservice.rs
@@ -27,6 +27,28 @@ fn works_with_basics() {
 }
 
 #[test]
+fn works_with_explicit_scale_transport() {
+    let input = quote! {
+        impl SomeService {
+            #[export(scale)]
+            pub async fn do_this(&mut self, p1: u32, p2: String) -> String {
+                format!("{p1}: ") + &p2
+            }
+
+            #[export]
+            pub fn this(&self, p1: bool) -> bool {
+                p1
+            }
+        }
+    };
+
+    let result = gservice(TokenStream::new(), input).to_string();
+    let result = prettyplease::unparse(&syn::parse_str(&result).unwrap());
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
 fn works_with_lifetimes_and_generics() {
     let input = quote! {
         impl<'a, 'b, T, U> SomeService<'a, 'b, T, U>

--- a/rs/macros/core/tests/snapshots/gservice__works_with_all_override_variants.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_all_override_variants.snap
@@ -87,7 +87,7 @@ impl InheritedServiceExposure<InheritedService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -108,7 +108,11 @@ impl InheritedServiceExposure<InheritedService> {
                 let result = self.method_three();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <inherited_service_meta::__MethodThreeParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        inherited_service_meta::__MethodThreeParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -137,7 +141,11 @@ impl InheritedServiceExposure<InheritedService> {
                 let result = self.renamed_by_route();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <inherited_service_meta::__RenamedByRouteParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        inherited_service_meta::__RenamedByRouteParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -158,7 +166,11 @@ impl InheritedServiceExposure<InheritedService> {
                 let result = self.renamed_by_id();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <inherited_service_meta::__RenamedByIdParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        inherited_service_meta::__RenamedByIdParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -178,7 +190,7 @@ impl InheritedServiceExposure<InheritedService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_allow_attrs.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_allow_attrs.snap
@@ -62,7 +62,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -76,7 +76,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -96,7 +100,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -110,7 +114,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this(request.p1, request.p2).await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/macros/core/tests/snapshots/gservice__works_with_basics.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_basics.snap
@@ -59,7 +59,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -73,7 +73,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -93,7 +97,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -107,7 +111,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this(request.p1, request.p2).await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<String>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/macros/core/tests/snapshots/gservice__works_with_crate_path.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_crate_path.snap
@@ -59,7 +59,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rename::gstd::{InvocationIo, CommandReply};
+        use sails_rename::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -73,7 +73,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rename::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rename::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rename::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -93,7 +97,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rename::gstd::{InvocationIo, CommandReply};
+        use sails_rename::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -107,7 +111,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this(request.p1, request.p2).await;
                 let value = 0u128;
                 if !sails_rename::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rename::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rename::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/macros/core/tests/snapshots/gservice__works_with_docs.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_docs.snap
@@ -62,7 +62,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -76,7 +76,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -96,7 +100,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -110,7 +114,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this(request.p1, request.p2).await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/macros/core/tests/snapshots/gservice__works_with_events.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_events.snap
@@ -63,7 +63,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -77,7 +77,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -99,7 +103,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -119,7 +127,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_explicit_scale_transport.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_explicit_scale_transport.snap
@@ -1,0 +1,197 @@
+---
+source: rs/macros/core/tests/gservice.rs
+expression: result
+---
+pub struct SomeServiceExposure<T> {
+    route_idx: u8,
+    inner: T,
+}
+impl<T: sails_rs::meta::ServiceMeta> sails_rs::gstd::services::Exposure
+for SomeServiceExposure<T> {
+    fn interface_id() -> sails_rs::meta::InterfaceId {
+        <T as sails_rs::meta::Identifiable>::INTERFACE_ID
+    }
+    fn route_idx(&self) -> u8 {
+        self.route_idx
+    }
+    fn check_asyncness(
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+    ) -> Option<bool> {
+        if !T::ASYNC {
+            return Some(false);
+        }
+        match (interface_id, entry_id) {
+            (id, 0u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(true)
+            }
+            (id, 1u16) if id == <T as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                Some(false)
+            }
+            _ => None,
+        }
+    }
+}
+impl<T> core::ops::Deref for SomeServiceExposure<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<T> core::ops::DerefMut for SomeServiceExposure<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl SomeServiceExposure<SomeService> {
+    #[export(scale)]
+    pub async fn do_this(&mut self, p1: u32, p2: String) -> String {
+        format!("{p1}: ") + &p2
+    }
+    #[export]
+    pub fn this(&self, p1: bool) -> bool {
+        p1
+    }
+    pub fn try_handle(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            (
+                id,
+                1u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let request: some_service_meta::__ThisParams = sails_rs::scale_codec::Decode::decode(
+                        &mut input,
+                    )
+                    .expect("Failed to decode params");
+                let result = self.this(request.p1);
+                let value = 0u128;
+                if !sails_rs::gstd::is_empty_tuple::<bool>() {
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
+                        &result,
+                        self.route_idx,
+                        |encoded_result| result_handler(encoded_result, value),
+                    );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
+                }
+                return Some(());
+            }
+            _ => None,
+        }
+    }
+    pub async fn try_handle_async(
+        mut self,
+        interface_id: sails_rs::meta::InterfaceId,
+        entry_id: u16,
+        mut input: &[u8],
+        result_handler: fn(&[u8], u128),
+    ) -> Option<()> {
+        use sails_rs::gstd::CommandReply;
+        match (interface_id, entry_id) {
+            (
+                id,
+                0u16,
+            ) if id
+                == <self::SomeService as sails_rs::meta::Identifiable>::INTERFACE_ID => {
+                let request: some_service_meta::__DoThisParams = sails_rs::scale_codec::Decode::decode(
+                        &mut input,
+                    )
+                    .expect("Failed to decode params");
+                let result = self.do_this(request.p1, request.p2).await;
+                let value = 0u128;
+                if !sails_rs::gstd::is_empty_tuple::<String>() {
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
+                        &result,
+                        self.route_idx,
+                        |encoded_result| result_handler(encoded_result, value),
+                    );
+                } else if false && value > 0 {
+                    result_handler(&[], value);
+                }
+                return Some(());
+            }
+            _ => None,
+        }
+    }
+}
+impl sails_rs::gstd::services::Service for SomeService {
+    type Exposure = SomeServiceExposure<Self>;
+    fn expose(self, route_idx: u8) -> Self::Exposure {
+        Self::Exposure {
+            route_idx,
+            inner: self,
+        }
+    }
+}
+mod some_service_meta {
+    use super::*;
+    const __INTERFACE_ID: sails_rs::meta::InterfaceId = {
+        let mut final_hash = sails_rs::keccak_const::Keccak256::new();
+        final_hash = final_hash
+            .update(&sails_rs::hash_fn!(command DoThis(u32, String) -> String));
+        final_hash = final_hash.update(&sails_rs::hash_fn!(query This(bool) -> bool));
+        let hash = final_hash.finalize();
+        sails_rs::meta::InterfaceId::from_bytes_32(hash)
+    };
+    impl sails_rs::meta::Identifiable for super::SomeService {
+        const INTERFACE_ID: sails_rs::meta::InterfaceId = __INTERFACE_ID;
+    }
+    impl sails_rs::meta::ServiceMeta for super::SomeService {
+        type CommandsMeta = CommandsMeta;
+        type QueriesMeta = QueriesMeta;
+        type EventsMeta = EventsMeta;
+        const BASE_SERVICES: &'static [sails_rs::meta::BaseServiceMeta] = &[];
+        const METHODS: &'static [sails_rs::meta::MethodMetadata] = &[
+            sails_rs::meta::MethodMetadata {
+                name: "DoThis",
+                entry_id: 0u16,
+                hash: sails_rs::hash_fn!(command DoThis(u32, String) -> String),
+                is_async: true,
+            },
+            sails_rs::meta::MethodMetadata {
+                name: "This",
+                entry_id: 1u16,
+                hash: sails_rs::hash_fn!(query This(bool) -> bool),
+                is_async: false,
+            },
+        ];
+        const ASYNC: bool = true;
+    }
+    sails_rs::invocation_io!(
+        pub struct __DoThisParams { pub (super) p1 : u32, pub (super) p2 : String, },
+        interface_id = __INTERFACE_ID, entry_id = 0u16,
+    );
+    sails_rs::invocation_io!(
+        pub struct __ThisParams { pub (super) p1 : bool, }, interface_id =
+        __INTERFACE_ID, entry_id = 1u16,
+    );
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum CommandsMeta {
+        DoThis(__DoThisParams, String),
+    }
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum QueriesMeta {
+        This(__ThisParams, bool),
+    }
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum NoEvents {}
+    pub type EventsMeta = NoEvents;
+}

--- a/rs/macros/core/tests/snapshots/gservice__works_with_export.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_export.snap
@@ -63,7 +63,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -77,7 +77,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -97,7 +101,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -114,7 +118,11 @@ impl SomeServiceExposure<SomeService> {
                 );
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<(u32, String)>() {
-                    <some_service_meta::__DoSomethingParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoSomethingParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/macros/core/tests/snapshots/gservice__works_with_extends.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_extends.snap
@@ -88,7 +88,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -102,7 +102,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -150,7 +154,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,

--- a/rs/macros/core/tests/snapshots/gservice__works_with_extends_and_lifetimes.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_extends_and_lifetimes.snap
@@ -78,7 +78,7 @@ impl<'a> ExtendedLifetimeExposure<ExtendedLifetime<'a>> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -94,7 +94,11 @@ impl<'a> ExtendedLifetimeExposure<ExtendedLifetime<'a>> {
                 let result = self.extended_name();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<String>() {
-                    <extended_lifetime_meta::__ExtendedNameParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        extended_lifetime_meta::__ExtendedNameParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -118,7 +122,11 @@ impl<'a> ExtendedLifetimeExposure<ExtendedLifetime<'a>> {
                 let result = self.name();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<String>() {
-                    <extended_lifetime_meta::__NameParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        extended_lifetime_meta::__NameParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -154,7 +162,7 @@ impl<'a> ExtendedLifetimeExposure<ExtendedLifetime<'a>> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,

--- a/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_events.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_events.snap
@@ -59,7 +59,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -76,7 +76,11 @@ where
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <my_generic_events_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        my_generic_events_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -96,7 +100,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_generics.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_generics.snap
@@ -56,7 +56,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -75,7 +75,11 @@ where
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -95,7 +99,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_methods_with_lifetimes.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_methods_with_lifetimes.snap
@@ -86,7 +86,7 @@ impl ReferenceServiceExposure<ReferenceService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -100,7 +100,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.add_byte(request.byte);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<&'static [u8]>() {
-                    <reference_service_meta::__AddByteParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__AddByteParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -122,7 +126,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.baked();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<&'static str>() {
-                    <reference_service_meta::__BakedParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__BakedParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -144,7 +152,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.incr();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<&'static ReferenceCount>() {
-                    <reference_service_meta::__IncrParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__IncrParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -164,7 +176,7 @@ impl ReferenceServiceExposure<ReferenceService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -178,7 +190,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.first_byte().await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<Option<&'static u8>>() {
-                    <reference_service_meta::__FirstByteParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__FirstByteParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -200,7 +216,11 @@ impl ReferenceServiceExposure<ReferenceService> {
                 let result = self.last_byte().await;
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<Option<&'static u8>>() {
-                    <reference_service_meta::__LastByteParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        reference_service_meta::__LastByteParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/macros/core/tests/snapshots/gservice__works_with_mixed_methods.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_mixed_methods.snap
@@ -93,7 +93,7 @@ impl InheritedServiceExposure<InheritedService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -114,7 +114,11 @@ impl InheritedServiceExposure<InheritedService> {
                 let result = self.foo();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <inherited_service_meta::__FooParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        inherited_service_meta::__FooParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -136,7 +140,11 @@ impl InheritedServiceExposure<InheritedService> {
                 let result = self.own_first();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <inherited_service_meta::__OwnFirstParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        inherited_service_meta::__OwnFirstParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -158,7 +166,11 @@ impl InheritedServiceExposure<InheritedService> {
                 let result = self.own_second();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <inherited_service_meta::__OwnSecondParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        inherited_service_meta::__OwnSecondParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -192,7 +204,7 @@ impl InheritedServiceExposure<InheritedService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,

--- a/rs/macros/core/tests/snapshots/gservice__works_with_overrides.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_overrides.snap
@@ -89,7 +89,7 @@ impl InheritedServiceExposure<InheritedService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -102,7 +102,11 @@ impl InheritedServiceExposure<InheritedService> {
                 let result = self.bar();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <inherited_service_meta::__BarParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        inherited_service_meta::__BarParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -131,7 +135,11 @@ impl InheritedServiceExposure<InheritedService> {
                 let result = self.foo();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <inherited_service_meta::__FooParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        inherited_service_meta::__FooParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -165,7 +173,7 @@ impl InheritedServiceExposure<InheritedService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,

--- a/rs/macros/core/tests/snapshots/gservice__works_with_reply_with_value.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_reply_with_value.snap
@@ -59,7 +59,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -73,7 +73,11 @@ impl SomeServiceExposure<SomeService> {
                 let result = self.this(request.p1);
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<bool>() {
-                    <some_service_meta::__ThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__ThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -93,7 +97,7 @@ impl SomeServiceExposure<SomeService> {
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -110,7 +114,11 @@ impl SomeServiceExposure<SomeService> {
                     .into();
                 let (result, value) = command_reply.to_tuple();
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <some_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        some_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),

--- a/rs/macros/core/tests/snapshots/gservice__works_with_special_lifetimes_and_events.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_special_lifetimes_and_events.snap
@@ -59,7 +59,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -77,7 +77,11 @@ where
                 let result = self.do_this();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u32>() {
-                    <my_generic_events_service_meta::__DoThisParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        my_generic_events_service_meta::__DoThisParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -97,7 +101,7 @@ where
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/macros/core/tests/snapshots/gservice__works_with_type_generics_used_only_by_impl.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_type_generics_used_only_by_impl.snap
@@ -66,7 +66,7 @@ impl<M: InfallibleStorage<Item = Metadata>> VftMetadataExposure<VftMetadata<M>> 
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             (
                 id,
@@ -82,7 +82,11 @@ impl<M: InfallibleStorage<Item = Metadata>> VftMetadataExposure<VftMetadata<M>> 
                 let result = self.decimals();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<u8>() {
-                    <vft_metadata_meta::__DecimalsParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        vft_metadata_meta::__DecimalsParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -106,7 +110,11 @@ impl<M: InfallibleStorage<Item = Metadata>> VftMetadataExposure<VftMetadata<M>> 
                 let result = self.name();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<String>() {
-                    <vft_metadata_meta::__NameParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        vft_metadata_meta::__NameParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -130,7 +138,11 @@ impl<M: InfallibleStorage<Item = Metadata>> VftMetadataExposure<VftMetadata<M>> 
                 let result = self.symbol();
                 let value = 0u128;
                 if !sails_rs::gstd::is_empty_tuple::<String>() {
-                    <vft_metadata_meta::__SymbolParams as sails_rs::gstd::InvocationIo>::with_optimized_encode(
+                    sails_rs::gstd::encode_invocation_payload::<
+                        vft_metadata_meta::__SymbolParams,
+                        _,
+                        _,
+                    >(
                         &result,
                         self.route_idx,
                         |encoded_result| result_handler(encoded_result, value),
@@ -150,7 +162,7 @@ impl<M: InfallibleStorage<Item = Metadata>> VftMetadataExposure<VftMetadata<M>> 
         mut input: &[u8],
         result_handler: fn(&[u8], u128),
     ) -> Option<()> {
-        use sails_rs::gstd::{InvocationIo, CommandReply};
+        use sails_rs::gstd::CommandReply;
         match (interface_id, entry_id) {
             _ => None,
         }

--- a/rs/macros/tests/ui/gservice_fails_export_duplicate_scale.rs
+++ b/rs/macros/tests/ui/gservice_fails_export_duplicate_scale.rs
@@ -1,0 +1,13 @@
+use sails_rs::prelude::*;
+
+struct SomeService;
+
+#[sails_rs::service]
+impl SomeService {
+    #[export(scale, scale)]
+    pub fn do_this(&self) -> u32 {
+        42
+    }
+}
+
+fn main() {}

--- a/rs/macros/tests/ui/gservice_fails_export_duplicate_scale.stderr
+++ b/rs/macros/tests/ui/gservice_fails_export_duplicate_scale.stderr
@@ -1,0 +1,5 @@
+error: `export` attribute cannot be parsed: duplicate `scale` flag in `#[export]`
+ --> tests/ui/gservice_fails_export_duplicate_scale.rs:7:7
+  |
+7 |     #[export(scale, scale)]
+  |       ^^^^^^

--- a/rs/macros/tests/ui/gservice_fails_export_duplicate_scale.stderr
+++ b/rs/macros/tests/ui/gservice_fails_export_duplicate_scale.stderr
@@ -1,5 +1,5 @@
 error: `export` attribute cannot be parsed: duplicate `scale` flag in `#[export]`
- --> tests/ui/gservice_fails_export_duplicate_scale.rs:7:7
+ --> tests/ui/gservice_fails_export_duplicate_scale.rs:7:21
   |
 7 |     #[export(scale, scale)]
-  |       ^^^^^^
+  |                     ^^^^^

--- a/rs/reflect-hash/Cargo.toml
+++ b/rs/reflect-hash/Cargo.toml
@@ -10,6 +10,10 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+alloy-primitives = { workspace = true, optional = true }
 gprimitives = { workspace = true, default-features = false, features = ["codec"] }
 keccak-const.workspace = true
 sails-reflect-hash-derive.workspace = true
+
+[features]
+alloy-primitives = ["dep:alloy-primitives"]

--- a/rs/reflect-hash/src/lib.rs
+++ b/rs/reflect-hash/src/lib.rs
@@ -286,6 +286,16 @@ impl ReflectHash for H160 {
     const HASH: [u8; 32] = Keccak256::new().update(b"H160").finalize();
 }
 
+#[cfg(feature = "alloy-primitives")]
+impl ReflectHash for alloy_primitives::Address {
+    const HASH: [u8; 32] = H160::HASH;
+}
+
+#[cfg(feature = "alloy-primitives")]
+impl ReflectHash for alloy_primitives::B256 {
+    const HASH: [u8; 32] = H256::HASH;
+}
+
 impl ReflectHash for U256 {
     const HASH: [u8; 32] = Keccak256::new().update(b"U256").finalize();
 }
@@ -339,5 +349,18 @@ mod tests {
         #[reflect_hash(crate = reflect_hash_crate)]
         #[allow(dead_code)]
         struct TestStruct(String);
+    }
+
+    #[cfg(feature = "alloy-primitives")]
+    #[test]
+    fn alloy_primitives_reuse_h160_h256_hashes() {
+        assert_eq!(
+            <alloy_primitives::Address as ReflectHash>::HASH,
+            <H160 as ReflectHash>::HASH,
+        );
+        assert_eq!(
+            <alloy_primitives::B256 as ReflectHash>::HASH,
+            <H256 as ReflectHash>::HASH,
+        );
     }
 }

--- a/rs/src/gstd/macros.rs
+++ b/rs/src/gstd/macros.rs
@@ -112,12 +112,22 @@ macro_rules! program_ctor {
 /// # Examples
 ///
 /// ```rust,ignore
+/// // Default: derives Decode + TypeInfo
 /// sails_rs::invocation_io!(
 ///     pub struct __FooParams {
 ///         pub(super) a: u32,
 ///         pub(super) b: String,
-///     }
+///     },
 ///     entry_id = 0,
+/// );
+///
+/// // ABI-only: derives TypeInfo only (no Decode)
+/// sails_rs::invocation_io!(
+///     pub struct __BarParams {
+///         pub(super) addr: Address,
+///     },
+///     entry_id = 1,
+///     decode = false,
 /// );
 /// ```
 #[macro_export]

--- a/rs/src/gstd/macros.rs
+++ b/rs/src/gstd/macros.rs
@@ -104,9 +104,10 @@ macro_rules! program_ctor {
 /// Declares an invocation params struct together with its metadata and
 /// [`crate::gstd::InvocationIo`] implementation.
 ///
-/// The generated struct always derives [`crate::Decode`] and
+/// By default the generated struct derives [`crate::Decode`] and
 /// [`crate::TypeInfo`], using `$crate::scale_codec` and `$crate::type_info`
-/// as the derive crate paths.
+/// as the derive crate paths. Pass `decode = false` for ABI-only metadata
+/// structs that should not derive [`crate::Decode`].
 ///
 /// # Examples
 ///
@@ -143,6 +144,58 @@ macro_rules! invocation_io {
         interface_id = $interface_id:expr,
         entry_id = $entry_id:expr $(,)?
     ) => {
+        $crate::invocation_io! {
+            @with_decode
+            $struct_vis struct $params_struct {
+                $( $field_vis $field : $ty, )*
+            },
+            interface_id = $interface_id,
+            entry_id = $entry_id,
+        }
+    };
+
+    (
+        $struct_vis:vis struct $params_struct:ident {
+            $( $field_vis:vis $field:ident : $ty:ty ),* $(,)?
+        },
+        entry_id = $entry_id:expr,
+        decode = false $(,)?
+    ) => {
+        $crate::invocation_io!(
+            $struct_vis struct $params_struct {
+                $( $field_vis $field : $ty, )*
+            },
+            interface_id = $crate::meta::InterfaceId::zero(),
+            entry_id = $entry_id,
+            decode = false,
+        );
+    };
+
+    (
+        $struct_vis:vis struct $params_struct:ident {
+            $( $field_vis:vis $field:ident : $ty:ty ),* $(,)?
+        },
+        interface_id = $interface_id:expr,
+        entry_id = $entry_id:expr,
+        decode = false $(,)?
+    ) => {
+        $crate::invocation_io! {
+            @without_decode
+            $struct_vis struct $params_struct {
+                $( $field_vis $field : $ty, )*
+            },
+            interface_id = $interface_id,
+            entry_id = $entry_id,
+        }
+    };
+
+    (@with_decode
+        $struct_vis:vis struct $params_struct:ident {
+            $( $field_vis:vis $field:ident : $ty:ty, )*
+        },
+        interface_id = $interface_id:expr,
+        entry_id = $entry_id:expr $(,)?
+    ) => {
         #[derive($crate::Decode, $crate::TypeInfo)]
         #[codec(crate = $crate::scale_codec)]
         #[type_info(crate = $crate::type_info)]
@@ -150,6 +203,40 @@ macro_rules! invocation_io {
             $( $field_vis $field: $ty, )*
         }
 
+        $crate::invocation_io! {
+            @impl_common
+            $params_struct,
+            interface_id = $interface_id,
+            entry_id = $entry_id,
+        }
+    };
+
+    (@without_decode
+        $struct_vis:vis struct $params_struct:ident {
+            $( $field_vis:vis $field:ident : $ty:ty, )*
+        },
+        interface_id = $interface_id:expr,
+        entry_id = $entry_id:expr $(,)?
+    ) => {
+        #[derive($crate::TypeInfo)]
+        #[type_info(crate = $crate::type_info)]
+        $struct_vis struct $params_struct {
+            $( $field_vis $field: $ty, )*
+        }
+
+        $crate::invocation_io! {
+            @impl_common
+            $params_struct,
+            interface_id = $interface_id,
+            entry_id = $entry_id,
+        }
+    };
+
+    (@impl_common
+        $params_struct:ident,
+        interface_id = $interface_id:expr,
+        entry_id = $entry_id:expr $(,)?
+    ) => {
         impl $crate::meta::Identifiable for $params_struct {
             const INTERFACE_ID: $crate::meta::InterfaceId = $interface_id;
         }
@@ -212,7 +299,7 @@ macro_rules! ok_or_throws {
         match $res {
             Ok(r) => r,
             Err(e) => {
-                let encoded = <$param as $crate::gstd::InvocationIo>::with_optimized_encode(
+                let encoded = $crate::gstd::encode_invocation_payload::<$param, _, _>(
                     &e,
                     $route_idx,
                     |encoded| encoded.to_vec(),

--- a/rs/src/gstd/mod.rs
+++ b/rs/src/gstd/mod.rs
@@ -102,46 +102,64 @@ impl<T: AsRef<[u8]>> core::fmt::Debug for HexSlice<T> {
     }
 }
 
+/// Invocation parameter metadata for a generated service method.
+///
+/// This trait intentionally does not require `Params: Decode`. SCALE dispatch
+/// adds that bound at the call site through [`decode_invocation_params`], while
+/// ABI-only methods can still use the same metadata type without requiring
+/// SCALE codec support for their parameters.
 pub trait InvocationIo: MethodMeta {
-    type Params: Decode;
+    type Params;
+}
 
-    fn decode_params(payload: impl AsRef<[u8]>) -> Result<Self::Params> {
-        let mut value = payload.as_ref();
-        let header: SailsMessageHeader = Decode::decode(&mut value).map_err(Error::Codec)?;
-        if header.interface_id() != Self::INTERFACE_ID {
-            return Err(Error::Rtl(RtlError::InvocationPrefixMismatches));
-        }
-        if header.entry_id() != Self::ENTRY_ID {
-            return Err(Error::Rtl(RtlError::InvocationPrefixMismatches));
-        }
-        let value: Self::Params = Decode::decode(&mut value).map_err(Error::Codec)?;
-        Ok(value)
+/// Decode the SCALE-encoded `Params` of an invocation, validating that the
+/// Sails message header's interface id and entry id match the target `I`.
+pub fn decode_invocation_params<I>(payload: impl AsRef<[u8]>) -> Result<I::Params>
+where
+    I: InvocationIo,
+    I::Params: Decode,
+{
+    let mut value = payload.as_ref();
+    let header: SailsMessageHeader = Decode::decode(&mut value).map_err(Error::Codec)?;
+    if header.interface_id() != I::INTERFACE_ID {
+        return Err(Error::Rtl(RtlError::InvocationPrefixMismatches));
     }
+    if header.entry_id() != I::ENTRY_ID {
+        return Err(Error::Rtl(RtlError::InvocationPrefixMismatches));
+    }
+    let value: I::Params = Decode::decode(&mut value).map_err(Error::Codec)?;
+    Ok(value)
+}
 
-    fn with_optimized_encode<T: Encode, R>(
-        value: &T,
-        route_idx: u8,
-        f: impl FnOnce(&[u8]) -> R,
-    ) -> R {
-        Self::with_optimized_encode_with_id(Self::INTERFACE_ID, Self::ENTRY_ID, value, route_idx, f)
-    }
+/// SCALE-encode a reply payload prefixed with the Sails header derived from `I`,
+/// passing the encoded bytes to the caller's closure.
+pub fn encode_invocation_payload<I, T, R>(value: &T, route_idx: u8, f: impl FnOnce(&[u8]) -> R) -> R
+where
+    I: InvocationIo,
+    T: Encode,
+{
+    encode_invocation_payload_with_id::<T, R>(I::INTERFACE_ID, I::ENTRY_ID, value, route_idx, f)
+}
 
-    fn with_optimized_encode_with_id<T: Encode, R>(
-        interface_id: InterfaceId,
-        entry_id: u16,
-        value: &T,
-        route_idx: u8,
-        f: impl FnOnce(&[u8]) -> R,
-    ) -> R {
-        let header = SailsMessageHeader::v1(interface_id, entry_id, route_idx);
-        let size = 16 + Encode::encoded_size(value);
-        stack_buffer::with_byte_buffer(size, |buffer| {
-            let mut buffer_writer = MaybeUninitBufferWriter::new(buffer);
-            Encode::encode_to(&header, &mut buffer_writer);
-            Encode::encode_to(value, &mut buffer_writer);
-            buffer_writer.with_buffer(f)
-        })
-    }
+/// SCALE-encode a reply payload with explicit interface and entry ids.
+pub fn encode_invocation_payload_with_id<T, R>(
+    interface_id: InterfaceId,
+    entry_id: u16,
+    value: &T,
+    route_idx: u8,
+    f: impl FnOnce(&[u8]) -> R,
+) -> R
+where
+    T: Encode,
+{
+    let header = SailsMessageHeader::v1(interface_id, entry_id, route_idx);
+    let size = 16 + Encode::encoded_size(value);
+    stack_buffer::with_byte_buffer(size, |buffer| {
+        let mut buffer_writer = MaybeUninitBufferWriter::new(buffer);
+        Encode::encode_to(&header, &mut buffer_writer);
+        Encode::encode_to(value, &mut buffer_writer);
+        buffer_writer.with_buffer(f)
+    })
 }
 
 pub fn with_optimized_encode<T: Encode, R>(

--- a/rs/type-registry/Cargo.toml
+++ b/rs/type-registry/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+alloy-primitives = { workspace = true, optional = true }
 gprimitives = { workspace = true, optional = true }
 sails-type-registry-derive = { workspace = true, optional = true }
 
@@ -18,8 +19,13 @@ trybuild.workspace = true
 
 [features]
 default = ["derive"]
+alloy-primitives = ["dep:alloy-primitives", "gprimitives"]
 derive = ["dep:sails-type-registry-derive"]
 gprimitives = ["dep:gprimitives"]
+
+[[test]]
+name = "alloy_primitives"
+required-features = ["alloy-primitives"]
 
 [[test]]
 name = "gprimitives"

--- a/rs/type-registry/src/trait_impls.rs
+++ b/rs/type-registry/src/trait_impls.rs
@@ -152,6 +152,27 @@ mod g_impls {
     }
 }
 
+#[cfg(feature = "alloy-primitives")]
+mod alloy_impls {
+    use super::*;
+
+    impl TypeInfo for alloy_primitives::Address {
+        type Identity = Self;
+
+        fn type_info(_registry: &mut Registry) -> Type {
+            Type::builder().gprimitive(crate::ty::GPrimitive::H160)
+        }
+    }
+
+    impl TypeInfo for alloy_primitives::B256 {
+        type Identity = Self;
+
+        fn type_info(_registry: &mut Registry) -> Type {
+            Type::builder().gprimitive(crate::ty::GPrimitive::H256)
+        }
+    }
+}
+
 impl TypeInfo for () {
     type Identity = Self;
     fn type_info(_registry: &mut Registry) -> Type {

--- a/rs/type-registry/tests/alloy_primitives.rs
+++ b/rs/type-registry/tests/alloy_primitives.rs
@@ -1,0 +1,29 @@
+use alloy_primitives::{Address, B256};
+use sails_type_registry::{
+    Registry,
+    ty::{GPrimitive, TypeDef},
+};
+
+macro_rules! assert_alloy_primitive {
+    ($registry:expr, $ty:ty, $expected_primitive:ident) => {
+        let id = $registry.register_type::<$ty>();
+        let ty = $registry.get_type(id).expect("Type should be in registry");
+        assert_eq!(ty.def, TypeDef::GPrimitive(GPrimitive::$expected_primitive));
+        assert!(
+            ty.module_path.is_empty(),
+            "Primitives should not have a path"
+        );
+        assert!(
+            ty.annotations.is_empty(),
+            "Primitives should not have annotations"
+        );
+    };
+}
+
+#[test]
+fn registers_alloy_primitives_as_existing_idl_primitives() {
+    let mut registry = Registry::new();
+
+    assert_alloy_primitive!(registry, Address, H160);
+    assert_alloy_primitive!(registry, B256, H256);
+}


### PR DESCRIPTION
Resolves #1263  .

## Summary

Extends `#[export]` on service methods with per-transport opt-in flags so a method can be exposed only through the Gear/SCALE dispatch path, only through the Solidity/`ethexe` ABI path, or both:

```rust
#[export(scale)] // SCALE dispatch only
#[export(ethabi)] // Solidity ABI dispatch only
#[export(scale, ethabi)] // both (same as bare #[export])
#[export(ethabi, payable)] // ethabi + payable
```

Plain `#[export]` remains backward-compatible and implies both transports.

## Why

Before this change, every `#[export]` method was generated into both the SCALE and Solidity ABI dispatch paths unconditionally. That made `#[export]` too coarse:

- A method meant only for Gear callers was still forced through `abi_decode_params` / `abi_encode_sequence`, requiring its types to satisfy `SolValue`.
- A method meant only for Solidity callers was still forced through SCALE `Decode`/`Encode`, requiring its types to satisfy `parity_scale_codec` bounds — blocking ABI-native primitives like `alloy_primitives::Address` / `B256`.

Transport selection decouples *contract membership* from *dispatch visibility*: `#[export]` still controls whether a method is part of the service's contract (IDL, `INTERFACE_ID`, method metadata), while the new flags control which runtime dispatch paths actually route to it.

## Core Invariant

`#[export]` controls contract membership; transport flags control runtime dispatch only.

- IDL metadata, `CommandsMeta` / `QueriesMeta`, `MethodMetadata`, method hashes, and `INTERFACE_ID` are computed from the **full** exported method surface regardless of transport visibility.
- Single-transport methods are annotated in the IDL with `#[annotate(scale)]` or `#[annotate(ethabi)]` so downstream consumers can see the restriction without losing the method itself.
- Only runtime dispatch generation (`try_handle` for SCALE, `try_handle_solidity` + `ServiceSignature::METHODS` for ABI) is filtered by transport.

## Key Changes

- **`rs/macros/core/src/export/args.rs`** — parse `scale` / `ethabi` flags; reject duplicate flags; reject `payable` without `ethabi` (with spans anchored on the offending token).
- **`rs/macros/core/src/shared.rs`** — propagate transport flags through `InvocationExport` and `FnBuilder`; add `has_scale_transport()` / `has_ethabi_transport()` helpers.
- **`rs/src/gstd/mod.rs`** — refactor `InvocationIo` into a marker trait (`type Params;` with no `Decode` bound); extract SCALE encode/decode helpers to free functions (`decode_invocation_params`, `encode_invocation_payload`, `encode_invocation_payload_with_id`) so ethabi-only params structs don't have to satisfy SCALE codec bounds.
- **`rs/src/gstd/macros.rs`** — extend `invocation_io!` with a `decode = false` variant that omits `#[derive(Decode)]` and `#[codec(...)]` for ethabi-only params.
- **`rs/macros/core/src/service/exposure.rs`** — filter generated SCALE dispatch arms by `has_scale_transport()`; migrate generated encode calls to the new `encode_invocation_payload` free function.
- **`rs/macros/core/src/service/ethexe.rs`** — filter generated Solidity dispatch arms and `ServiceSignature::METHODS` by `has_ethabi_transport()`.
- **`rs/macros/core/src/service/meta.rs`** — emit `#[annotate(scale)]` / `#[annotate(ethabi)]` for single-transport methods; **metadata and interface hashing remain unfiltered**.
- **Alloy primitive support** (`rs/reflect-hash`, `rs/type-registry`) — `TypeInfo` + `ReflectHash` for `alloy_primitives::Address` / `B256`, mapped to the same logical IDL shapes as `H160` / `H256`, so ethabi-only methods can use ABI-native types in IDL/hash generation.

## Test Plan

- [x] Macro snapshot tests (`insta`) cover scale-only, ethabi-only, dual, mixed, and backward-compatible bare `#[export]`.
- [x] Snapshot asserts `CommandsMeta` / `QueriesMeta` / `METHODS` / `INTERFACE_ID` include every exported method regardless of transport.
- [x] Snapshot asserts single-transport methods carry `#[annotate(scale)]` / `#[annotate(ethabi)]`.
- [x] Snapshot verifies ethabi-only params structs are generated without `#[derive(Decode)]`.
- [x] Trybuild UI tests reject duplicate `ethabi`, duplicate `scale`, and `payable` without `ethabi`.
- [x] Trybuild pass fixture compiles an ethabi-only method using `alloy_primitives::Address` / `B256`.
- [x] Runtime wrong-transport dispatch (`try_handle` on ethabi-only, `try_handle_solidity` on scale-only) returns `None`.

## Out of Scope

- Program constructors (`#[ctor]` / `program_ctor!`) remain dual-transport. Constructor transport selection is a separate design problem.
- New IDL primitive names for `Address` / `B256` are deferred; they reuse `H160` / `H256` shapes for now.
- Cross-transport runtime diagnostics stay at the existing "Unknown request" fall-through.
