### PR TITLE
feat: State trait, pattern, doc, examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,34 +746,85 @@ which can be used as parameters and return values in service methods.
 ### Working with Data
 
 In the real world, almost all apps work with some form of data, and apps developed
-using `Sails` are no exception. As discussed in the [Application](#application) section,
-services are instantiated for every incoming request message, indicating that these
-services are stateless. However, there are a few ways to enable your services to
-maintain some state. In this case, the state will be treated as external to the service.
+using `Sails` are no exception. As discussed in the [Application](#application)
+section, services are instantiated for every incoming request message, so they
+should treat persistent data as state owned outside the service instance.
 
-The most recommended way is demonstrated in the [Counter](examples/demo/app/src/counter/)
-service, where the data is stored as part of the program and passed to the service
-via `RefCell`. The service module merely defines the shape of the data but requires
-the data itself to be passed from the outside. This option provides you with full
-flexibility and allows you to unit test your services in a multi-threaded environment,
-ensuring the tests do not affect each other.
+`Sails` provides two traits for abstracting over state storage:
 
-Another method is illustrated in the [RmrkCatalog](examples/rmrk/catalog/app/src/services/)
-and [RmrkResource](examples/rmrk/resource/app/src/services/) services, where the data
-is stored in static variables within the service module. This strategy ensures that the
-state remains completely hidden from the outside, making the service entirely self-contained.
-However, this approach is not ideal for unit testing in a multi-threaded environment
-because each test can potentially influence others. Additionally, it's important
-not to overlook calling the service's `seed` method before its first use.
+- `State` — read access; `read(&self) -> Result<impl Deref<Target = Item>, Error>`
+- `StateMut: State` — write access; `write(&mut self) -> Result<impl DerefMut<Target = Item>, Error>`
 
-You can also explore other approaches, such as making a service require `&'a mut` for its
-data (which makes the service non-clonable), or using `Cell` (which requires data copying,
-incurring additional costs).
+Both traits use an associated `Error` type. Backends that cannot fail (e.g. `RefCell<T>`)
+set `Error = Infallible`, which unlocks the `.get()` and `.get_mut()` infallible shortcuts.
 
-In all scenarios, except when using `Cell`, it's crucial to consider the static nature
-of data, especially during asynchronous calls within service methods. This implies that
-data accessed before initiating an asynchronous call might change by the time the call
-completes. See the [RmrkResource](examples/rmrk/resource/app/src/services/) service's
+Built-in implementations are provided for `RefCell<T>`, `&RefCell<T>`,
+`Rc<RefCell<T>>`, and the blanket `&mut S` / `&S` forwarding impls. Custom wrappers
+(e.g. a pausing or rate-limiting layer) implement the traits directly and compose
+transparently.
+
+The recommended pattern is to make a service generic over its state handle:
+
+```rust
+pub struct CounterService<S: StateMut<Item = CounterData, Error = Infallible> = RefCell<CounterData>> {
+    data: S,
+}
+
+impl<S: StateMut<Item = CounterData, Error = Infallible>> CounterService<S> {
+    pub fn new(data: S) -> Self { Self { data } }
+}
+
+#[service]
+impl<S: StateMut<Item = CounterData, Error = Infallible>> CounterService<S> {
+    #[export]
+    pub fn add(&mut self, value: u32) -> u32 {
+        let mut data = self.data.get_mut();
+        data.counter += value;
+        data.counter
+    }
+}
+```
+
+The program owns the `RefCell<CounterData>` and passes a shared reference to the service:
+
+```rust
+pub struct MyProgram {
+    counter_data: RefCell<CounterData>,
+}
+
+#[program]
+impl MyProgram {
+    pub fn counter(&self) -> CounterService<&RefCell<CounterData>> {
+        CounterService::new(&self.counter_data)
+    }
+}
+```
+
+Unit tests can use an owned `RefCell` (the default `S`) or `&mut RefCell` without any
+program scaffolding:
+
+```rust
+let data = RefCell::new(CounterData::new(0));
+let mut svc = CounterService::new(&data).expose(0);
+assert_eq!(svc.add(5), 5);
+```
+
+This is the most recommended approach and is demonstrated in the
+[Counter](examples/demo/app/src/counter/) service. It keeps state ownership clear,
+services fully unit-testable, and leaves room for cross-cutting wrappers without
+changing the service itself.
+
+You can still store data in static variables inside a service module, as shown
+by the [RmrkCatalog](examples/rmrk/catalog/app/src/services/) and
+[RmrkResource](examples/rmrk/resource/app/src/services/) services. This hides the
+state from the outside and makes the service self-contained, but it is harder to
+isolate in tests because one test can affect another. It also requires explicit
+initialization such as calling the service's `seed` method before first use.
+
+In all scenarios, except when using `Cell` (which requires data copying), it's crucial to consider the static nature of data, especially during
+asynchronous calls within service methods. This implies that data accessed before
+initiating an asynchronous call might change by the time the call completes. See the
+[RmrkResource](examples/rmrk/resource/app/src/services/) service's
 `add_part_to_resource` method for more details.
 
 ### Events

--- a/examples/demo/app/src/counter/README.md
+++ b/examples/demo/app/src/counter/README.md
@@ -1,4 +1,4 @@
 # Counter Service
 
-This service demonstrates a few features. The first one is the recommoned way to
+This service demonstrates a few features. The first one is the recommended way to
 maintain a service's state. The second one is the use of events.

--- a/examples/demo/app/src/counter/mod.rs
+++ b/examples/demo/app/src/counter/mod.rs
@@ -24,46 +24,134 @@ pub enum CounterEvents {
     Subtracted(u32),
 }
 
-pub struct CounterService<'a> {
-    data: &'a RefCell<CounterData>,
+// `CounterService` is generic over its state handle `S: StateMut`. The impl
+// stays agnostic of how the data is stored — any type that implements
+// `StateMut<Item = CounterData, Error = Infallible>` works:
+// a `&RefCell<CounterData>` borrowed from program state (production default),
+// an owned `RefCell<CounterData>`, an `Rc<RefCell<CounterData>>`, a
+// `&mut RefCell<CounterData>` (via the `&mut S` blanket in `state.rs`), or a
+// custom wrapper (pausing, metering, etc.).
+pub struct CounterService<
+    S: StateMut<Item = CounterData, Error = Infallible> = RefCell<CounterData>,
+> {
+    data: S,
 }
 
-impl<'a> CounterService<'a> {
-    // Service constrctor demands a reference to the data to be passed
-    // from the outside.
-    pub fn new(data: &'a RefCell<CounterData>) -> Self {
+impl<S: StateMut<Item = CounterData, Error = Infallible>> CounterService<S> {
+    // Service constructor demands the state handle to be passed from outside.
+    pub fn new(data: S) -> Self {
         Self { data }
     }
 }
 
 // Declare the service can emit events of type CounterEvents.
 #[service(events = CounterEvents)]
-impl CounterService<'_> {
+impl<S: StateMut<Item = CounterData, Error = Infallible>> CounterService<S> {
     /// Add a value to the counter
     #[export]
     pub fn add(&mut self, value: u32) -> u32 {
-        let mut data_mut = self.data.borrow_mut();
-        data_mut.counter += value;
+        let counter = {
+            // Access mutable state
+            let mut data_mut = self.data.get_mut();
+            data_mut.counter += value;
+            data_mut.counter
+        };
+
         // Emit event right before the method returns via
         // the generated `emit_event` method.
         self.emit_event(CounterEvents::Added(value)).unwrap();
-        data_mut.counter
+        counter
     }
 
-    /// Substract a value from the counter
+    /// Subtract a value from the counter
     #[export]
     pub fn sub(&mut self, value: u32) -> u32 {
-        let mut data_mut = self.data.borrow_mut();
-        data_mut.counter -= value;
+        let counter = {
+            // Access mutable state
+            let mut data_mut = self.data.get_mut();
+            data_mut.counter -= value;
+            data_mut.counter
+        };
         // Emit event right before the method returns via
         // the generated `emit_event` method.
         self.emit_event(CounterEvents::Subtracted(value)).unwrap();
-        data_mut.counter
+        counter
     }
 
     /// Get the current value
     #[export]
     pub fn value(&self) -> u32 {
-        self.data.borrow().counter
+        self.data.get().counter
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sails_rs::gstd::services::Service;
+
+    #[test]
+    fn value_returns_initial_state() {
+        let data = RefCell::new(CounterData::new(7));
+        let service = CounterService::new(&data).expose(0);
+        assert_eq!(service.value(), 7);
+    }
+
+    #[test]
+    fn add_increments_and_emits_event() {
+        Syscall::with_message_id(MessageId::from(1));
+
+        let data = RefCell::new(CounterData::new(0));
+        let mut service = CounterService::new(&data).expose(1);
+        let mut emitter = service.emitter();
+
+        assert_eq!(service.add(5), 5);
+        assert_eq!(service.add(3), 8);
+        assert_eq!(data.borrow().counter, 8);
+
+        let events = emitter.take_events();
+        assert_eq!(events, [CounterEvents::Added(5), CounterEvents::Added(3)]);
+    }
+
+    #[test]
+    fn sub_decrements_and_emits_event() {
+        Syscall::with_message_id(MessageId::from(2));
+
+        let data = RefCell::new(CounterData::new(10));
+        let mut service = CounterService::new(&data).expose(1);
+        let mut emitter = service.emitter();
+
+        assert_eq!(service.sub(4), 6);
+        assert_eq!(data.borrow().counter, 6);
+
+        let events = emitter.take_events();
+        assert_eq!(events, [CounterEvents::Subtracted(4)]);
+    }
+
+    // Demonstrates the StateMut abstraction with an owned `RefCell` (the
+    // default `S`) — no borrow plumbing needed.
+    #[test]
+    fn works_with_owned_refcell() {
+        Syscall::with_message_id(MessageId::from(3));
+
+        let service: CounterService = CounterService::new(RefCell::new(CounterData::new(0)));
+        let mut exposed = service.expose(1);
+
+        assert_eq!(exposed.add(2), 2);
+        assert_eq!(exposed.value(), 2);
+    }
+
+    // Demonstrates the `&mut S` blanket impl in `state.rs`: passing
+    // `&mut RefCell<T>` satisfies `StateMut` without a new concrete impl.
+    #[test]
+    fn works_with_mut_ref_to_refcell() {
+        Syscall::with_message_id(MessageId::from(4));
+
+        let mut data = RefCell::new(CounterData::new(0));
+        let service = CounterService::new(&mut data);
+        let mut exposed = service.expose(1);
+
+        assert_eq!(exposed.add(2), 2);
+        assert_eq!(exposed.value(), 2);
     }
 }

--- a/examples/demo/app/src/lib.rs
+++ b/examples/demo/app/src/lib.rs
@@ -29,6 +29,11 @@ fn dog_data() -> &'static RefCell<walker::WalkerData> {
     }
 }
 
+// `DemoProgram` is the on-chain program state. The `#[program]` macro emits a
+// hidden `wasm` submodule that holds it as `static mut PROGRAM: Option<DemoProgram> = None;`
+// and wires the WASM `init`/`handle` entry points to construct, then borrow it
+// for every incoming message. So fields declared here live as long as the
+// program is deployed on the network.
 pub struct DemoProgram {
     // Counter data has the same lifetime as the program itself, i.e. it will
     // live as long as the program is available on the network.
@@ -73,6 +78,7 @@ impl DemoProgram {
             ref_data: 42,
         })
     }
+
     #[export(unwrap_result)]
     pub fn new_with_error(value: u32) -> Result<Self, String> {
         if value == 0 {
@@ -96,7 +102,7 @@ impl DemoProgram {
     }
 
     // Exposing another service
-    pub fn counter(&self) -> counter::CounterService<'_> {
+    pub fn counter(&self) -> counter::CounterService<&RefCell<counter::CounterData>> {
         counter::CounterService::new(&self.counter_data)
     }
 
@@ -117,7 +123,7 @@ impl DemoProgram {
         value_fee::FeeService::new(10_000_000_000_000)
     }
 
-    pub fn validator(&self) -> validator::Validator<'_> {
+    pub fn validator(&self) -> validator::Validator<&RefCell<validator::ValidatorData>> {
         validator::Validator::new(&self.validator_data)
     }
 

--- a/examples/demo/app/src/validator/mod.rs
+++ b/examples/demo/app/src/validator/mod.rs
@@ -11,12 +11,13 @@ impl ValidatorData {
     }
 }
 
-pub struct Validator<'a> {
-    data: &'a RefCell<ValidatorData>,
+pub struct Validator<S: StateMut<Item = ValidatorData, Error = Infallible> = RefCell<ValidatorData>>
+{
+    data: S,
 }
 
-impl<'a> Validator<'a> {
-    pub fn new(data: &'a RefCell<ValidatorData>) -> Self {
+impl<S: StateMut<Item = ValidatorData, Error = Infallible>> Validator<S> {
+    pub fn new(data: S) -> Self {
         Self { data }
     }
 }
@@ -29,7 +30,7 @@ pub enum ValidationError {
 }
 
 #[service]
-impl<'a> Validator<'a> {
+impl<S: StateMut<Item = ValidatorData, Error = Infallible>> Validator<S> {
     #[export(unwrap_result)]
     pub fn validate_range(
         &mut self,
@@ -38,10 +39,10 @@ impl<'a> Validator<'a> {
         max: u32,
     ) -> Result<u32, ValidationError> {
         if value < min {
-            self.data.borrow_mut().total_errors += 1;
+            self.data.get_mut().total_errors += 1;
             Err(ValidationError::TooSmall)
         } else if value > max {
-            self.data.borrow_mut().total_errors += 1;
+            self.data.get_mut().total_errors += 1;
             Err(ValidationError::TooBig)
         } else {
             Ok(value)
@@ -51,7 +52,7 @@ impl<'a> Validator<'a> {
     #[export(unwrap_result)]
     pub fn validate_nonzero(&mut self, value: u32) -> Result<(), String> {
         if value == 0 {
-            self.data.borrow_mut().total_errors += 1;
+            self.data.get_mut().total_errors += 1;
             Err("Value is zero".to_string())
         } else {
             Ok(())
@@ -69,6 +70,6 @@ impl<'a> Validator<'a> {
 
     #[export]
     pub fn total_errors(&self) -> u32 {
-        self.data.borrow().total_errors
+        self.data.get().total_errors
     }
 }

--- a/examples/demo/client/demo_client.idl
+++ b/examples/demo/client/demo_client.idl
@@ -17,7 +17,7 @@ service Counter@0x579d6daba41b7d82 {
     functions {
         /// Add a value to the counter
         Add(value: u32) -> u32;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         Sub(value: u32) -> u32;
         /// Get the current value
         @query

--- a/examples/demo/client/src/demo_client.rs
+++ b/examples/demo/client/src/demo_client.rs
@@ -175,7 +175,7 @@ pub mod counter {
         type Env: sails_rs::client::GearEnv;
         /// Add a value to the counter
         fn add(&mut self, value: u32) -> sails_rs::client::PendingCall<io::Add, Self::Env>;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         fn sub(&mut self, value: u32) -> sails_rs::client::PendingCall<io::Sub, Self::Env>;
         /// Get the current value
         fn value(&self) -> sails_rs::client::PendingCall<io::Value, Self::Env>;

--- a/examples/demo/walker/src/lib.rs
+++ b/examples/demo/walker/src/lib.rs
@@ -20,28 +20,28 @@ pub enum WalkerEvents {
     Walked { from: (i32, i32), to: (i32, i32) },
 }
 
-// Service extension requires the service to implement `Clone`
+// Yet another example of using `StateMut` for service state.
+// This time it demonstrates use of static lifetime with `RefCell<T>`
 #[derive(Clone)]
-pub struct WalkerService {
-    // Yet another example of using `RefCell` for service
-    // state. This time it demonstrates use of static lifetime
-    // even though it is not the best option
-    data: &'static RefCell<WalkerData>,
+pub struct WalkerService<
+    S: StateMut<Item = WalkerData, Error = Infallible> = &'static RefCell<WalkerData>,
+> {
+    data: S,
 }
 
-impl WalkerService {
-    pub fn new(data: &'static RefCell<WalkerData>) -> Self {
+impl<S: StateMut<Item = WalkerData, Error = Infallible>> WalkerService<S> {
+    pub fn new(data: S) -> Self {
         Self { data }
     }
 }
 
 #[service(events = WalkerEvents)]
-impl WalkerService {
+impl<S: StateMut<Item = WalkerData, Error = Infallible>> WalkerService<S> {
     #[export]
     pub fn walk(&mut self, dx: i32, dy: i32) {
         let from = self.position();
         {
-            let mut data = self.data.borrow_mut();
+            let mut data = self.data.get_mut();
             data.x += dx;
             data.y += dy;
         }
@@ -51,7 +51,7 @@ impl WalkerService {
 
     #[export]
     pub fn position(&self) -> (i32, i32) {
-        let data = self.data.borrow();
+        let data = self.data.get();
         (data.x, data.y)
     }
 }

--- a/js/cli/test/__snapshots__/generator.test.js.snap
+++ b/js/cli/test/__snapshots__/generator.test.js.snap
@@ -173,7 +173,7 @@ export class Counter {
   }
 
   /**
-   * Substract a value from the counter
+   * Subtract a value from the counter
   */
   public sub(value: number): TransactionBuilder<number> {
     if (!this._program.programId) throw new Error('Program ID is not set');
@@ -817,7 +817,7 @@ export class Counter {
   }
 
   /**
-   * Substract a value from the counter
+   * Subtract a value from the counter
   */
   public sub(value: number): TransactionBuilder<number> {
     if (!this._program.programId) throw new Error('Program ID is not set');

--- a/js/example/src/lib.ts
+++ b/js/example/src/lib.ts
@@ -192,7 +192,7 @@ export class Counter {
   }
 
   /**
-   * Substract a value from the counter
+   * Subtract a value from the counter
    */
   public sub(value: number): TransactionBuilder<number> {
     if (!this._program.programId) throw new Error('Program ID is not set');

--- a/js/test/demo-v2/demo.idl
+++ b/js/test/demo-v2/demo.idl
@@ -17,7 +17,7 @@ service Counter@0x579d6daba41b7d82 {
     functions {
         /// Add a value to the counter
         Add(value: u32) -> u32;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         Sub(value: u32) -> u32;
         /// Get the current value
         @query

--- a/js/test/demo-v2/lib.ts
+++ b/js/test/demo-v2/lib.ts
@@ -187,7 +187,7 @@ export class Counter {
     }
 
     /**
-     * Substract a value from the counter
+     * Subtract a value from the counter
      */
     public sub(value: number): TransactionBuilderWithHeader<number> {
         return new TransactionBuilderWithHeader<number>(

--- a/net/examples/Sails.DemoClient/demo.idl
+++ b/net/examples/Sails.DemoClient/demo.idl
@@ -31,7 +31,7 @@ constructor {
 service Counter {
   /// Add a value to the counter
   Add : (value: u32) -> u32;
-  /// Substract a value from the counter
+  /// Subtract a value from the counter
   Sub : (value: u32) -> u32;
   /// Get the current value
   query Value : () -> u32;

--- a/net/tests/Sails.Client.Tests/idl/demo.idl
+++ b/net/tests/Sails.Client.Tests/idl/demo.idl
@@ -31,7 +31,7 @@ constructor {
 service Counter {
   /// Add a value to the counter
   Add : (value: u32) -> u32;
-  /// Substract a value from the counter
+  /// Subtract a value from the counter
   Sub : (value: u32) -> u32;
   /// Get the current value
   query Value : () -> u32;

--- a/net/tests/Sails.ClientGenerator.Tests/idl/demo.idl
+++ b/net/tests/Sails.ClientGenerator.Tests/idl/demo.idl
@@ -31,7 +31,7 @@ constructor {
 service Counter {
   /// Add a value to the counter
   Add : (value: u32) -> u32;
-  /// Substract a value from the counter
+  /// Subtract a value from the counter
   Sub : (value: u32) -> u32;
   /// Get the current value
   query Value : () -> u32;

--- a/rs/client-gen-js/tests/snapshots/generator__demo_mvp_generation.snap
+++ b/rs/client-gen-js/tests/snapshots/generator__demo_mvp_generation.snap
@@ -191,7 +191,7 @@ export class Counter {
     }
 
     /**
-     * Substract a value from the counter
+     * Subtract a value from the counter
      */
     public sub(value: number): TransactionBuilderWithHeader<number> {
         return new TransactionBuilderWithHeader<number>(

--- a/rs/client-gen-v2/tests/idls/full_coverage.idl
+++ b/rs/client-gen-v2/tests/idls/full_coverage.idl
@@ -129,7 +129,7 @@ service Counter {
     functions {
         /// Add a value to the counter
         Add(value: u32) -> u32;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         Sub(value: u32) -> u32;
         /// Get the current value
         @query

--- a/rs/client-gen-v2/tests/snapshots/generator__full_coverage.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__full_coverage.snap
@@ -310,7 +310,7 @@ pub mod counter {
         type Env: sails_rs::client::GearEnv;
         /// Add a value to the counter
         fn add(&mut self, value: u32) -> sails_rs::client::PendingCall<io::Add, Self::Env>;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         fn sub(&mut self, value: u32) -> sails_rs::client::PendingCall<io::Sub, Self::Env>;
         /// Get the current value
         fn value(&self) -> sails_rs::client::PendingCall<io::Value, Self::Env>;

--- a/rs/client-gen-v2/tests/snapshots/generator__full_with_sails_path.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__full_with_sails_path.snap
@@ -393,7 +393,7 @@ pub mod counter {
         type Env: my_crate::sails::client::GearEnv;
         /// Add a value to the counter
         fn add(&mut self, value: u32) -> my_crate::sails::client::PendingCall<io::Add, Self::Env>;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         fn sub(&mut self, value: u32) -> my_crate::sails::client::PendingCall<io::Sub, Self::Env>;
         /// Get the current value
         fn value(&self) -> my_crate::sails::client::PendingCall<io::Value, Self::Env>;

--- a/rs/client-gen/tests/generated/demo_client_v1.rs
+++ b/rs/client-gen/tests/generated/demo_client_v1.rs
@@ -140,7 +140,7 @@ pub mod counter {
         type Env: sails_rs::client::GearEnv;
         /// Add a value to the counter
         fn add(&mut self, value: u32) -> sails_rs::client::PendingCall<io::Add, Self::Env>;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         fn sub(&mut self, value: u32) -> sails_rs::client::PendingCall<io::Sub, Self::Env>;
         /// Get the current value
         fn value(&self) -> sails_rs::client::PendingCall<io::Value, Self::Env>;

--- a/rs/client-gen/tests/generator.rs
+++ b/rs/client-gen/tests/generator.rs
@@ -206,7 +206,7 @@ fn full_with_sails_path() {
         service Counter {
             /// Add a value to the counter
             Add : (value: u32) -> u32;
-            /// Substract a value from the counter
+            /// Subtract a value from the counter
             Sub : (value: u32) -> u32;
             /// Get the current value
             query Value : () -> u32;

--- a/rs/client-gen/tests/idls/demo.idl
+++ b/rs/client-gen/tests/idls/demo.idl
@@ -50,7 +50,7 @@ service PingPong {
 service Counter {
   /// Add a value to the counter
   Add : (value: u32) -> u32;
-  /// Substract a value from the counter
+  /// Subtract a value from the counter
   Sub : (value: u32) -> u32;
   /// Get the current value
   query Value : () -> u32;

--- a/rs/client-gen/tests/snapshots/generator__demo_works.snap
+++ b/rs/client-gen/tests/snapshots/generator__demo_works.snap
@@ -144,7 +144,7 @@ pub mod counter {
         type Env: sails_rs::client::GearEnv;
         /// Add a value to the counter
         fn add(&mut self, value: u32) -> sails_rs::client::PendingCall<io::Add, Self::Env>;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         fn sub(&mut self, value: u32) -> sails_rs::client::PendingCall<io::Sub, Self::Env>;
         /// Get the current value
         fn value(&self) -> sails_rs::client::PendingCall<io::Value, Self::Env>;

--- a/rs/client-gen/tests/snapshots/generator__full_with_sails_path.snap
+++ b/rs/client-gen/tests/snapshots/generator__full_with_sails_path.snap
@@ -160,7 +160,7 @@ pub mod counter {
         type Env: my_crate::sails::client::GearEnv;
         /// Add a value to the counter
         fn add(&mut self, value: u32) -> my_crate::sails::client::PendingCall<io::Add, Self::Env>;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         fn sub(&mut self, value: u32) -> my_crate::sails::client::PendingCall<io::Sub, Self::Env>;
         /// Get the current value
         fn value(&self) -> my_crate::sails::client::PendingCall<io::Value, Self::Env>;

--- a/rs/idl-ast/tests/fixture/mod.rs
+++ b/rs/idl-ast/tests/fixture/mod.rs
@@ -157,7 +157,7 @@ pub fn counter_service() -> ServiceUnit {
                 throws: None,
                 kind: FunctionKind::Command,
                 entry_id: 1,
-                docs: vec!["Substract a value from the counter".to_string()],
+                docs: vec!["Subtract a value from the counter".to_string()],
                 annotations: vec![],
             },
             ServiceFunc {

--- a/rs/idl-ast/tests/snapshots/serde__idl_doc.snap
+++ b/rs/idl-ast/tests/snapshots/serde__idl_doc.snap
@@ -157,7 +157,7 @@ expression: serialized
           "kind": "command",
           "entry_id": 1,
           "docs": [
-            "Substract a value from the counter"
+            "Subtract a value from the counter"
           ]
         },
         {

--- a/rs/idl-ast/tests/snapshots/templates__idl_service.snap
+++ b/rs/idl-ast/tests/snapshots/templates__idl_service.snap
@@ -17,7 +17,7 @@ service Counter {
     functions {
         /// Add a value to the counter
         Add(value: u32) -> u32;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         Sub(value: u32) -> u32;
         /// Get the current value
         @query

--- a/rs/idl-parser-v2/tests/idls/demo.idl
+++ b/rs/idl-parser-v2/tests/idls/demo.idl
@@ -18,7 +18,7 @@ service Counter@0x579d6daba41b7d82 {
     functions {
         /// Add a value to the counter
         Add(value: u32) -> u32;
-        /// Substract a value from the counter
+        /// Subtract a value from the counter
         Sub(value: u32) -> u32;
         /// Get the current value
         @query

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -43,5 +43,6 @@ mod address;
 pub mod prelude;
 #[cfg(feature = "ethexe")]
 pub mod solidity;
+pub mod state;
 mod types;
 mod utils;

--- a/rs/src/prelude.rs
+++ b/rs/src/prelude.rs
@@ -11,10 +11,10 @@ pub use alloc::{
     vec::Vec,
 };
 pub use core::{
-    any, array, ascii, assert_eq, assert_ne, cell, char, clone, cmp, convert, debug_assert,
-    debug_assert_eq, debug_assert_ne, default, future, hash, hint, iter, marker, matches, mem, num,
-    ops, option, panic, pin, prelude::rust_2021::*, primitive, ptr, result, slice, task, time,
-    todo, unimplemented, unreachable, write, writeln,
+    any, array, ascii, assert_eq, assert_ne, cell, char, clone, cmp, convert, convert::Infallible,
+    debug_assert, debug_assert_eq, debug_assert_ne, default, future, hash, hint, iter, marker,
+    matches, mem, num, ops, option, panic, pin, prelude::rust_2024::*, primitive, ptr, result,
+    slice, task, time, todo, unimplemented, unreachable, write, writeln,
 };
 
 /// Collection types.
@@ -46,6 +46,7 @@ pub use crate::gstd::{
     CommandReply, EventEmitter, SailsEvent, Syscall, event, export, program, service,
     services::Exposure as _, services::ExposureWithEvents as _,
 };
+pub use crate::state::{State, StateMut};
 pub use crate::types::*;
 pub use gear_core_errors::{
     self as gear_core_errors, ErrorReplyReason, ReplyCode, SignalCode, SimpleExecutionError,

--- a/rs/src/state.rs
+++ b/rs/src/state.rs
@@ -1,0 +1,415 @@
+//! State abstraction for single-threaded WASM contracts.
+//!
+//! Services hold a generic state handle and access it through two traits:
+//! [`State`] for reads and [`StateMut`] for writes. Both return guards
+//! ([`Deref`]/[`DerefMut`]) wrapped in `Result` so backends that can fail
+//! (e.g. paused, expired) report the failure inline. Backends that cannot
+//! fail set `Error = Infallible` and expose [`State::get`] / [`StateMut::get_mut`]
+//! shortcuts that return the guard directly.
+//!
+//! `read` takes `&self`; `write` takes `&mut self`. The signatures match
+//! idiomatic Rust ownership rules even though the underlying storage usually
+//! relies on interior mutability — the `&mut self` on `write` constrains the
+//! *handle*, not the data.
+//!
+//! ## Implementations
+//!
+//! - [`RefCell<T>`] and [`Rc<RefCell<T>>`] implement both traits with
+//!   `Error = Infallible`.
+//! - `&RefCell<T>` is also a `StateMut` backend; this is the canonical
+//!   service-field type when the program owns the cells and services borrow
+//!   them.
+//! - Blanket impls forward `&S` (read-only) and `&mut S` (read + write) to
+//!   the underlying `S`, so any wrapper composes naturally.
+//!
+//! ## Composition
+//!
+//! Cross-cutting concerns (pausing, rate-limiting, metering) are expressed
+//! as wrappers that themselves implement `State`/`StateMut`, not as parallel
+//! trait hierarchies.
+
+extern crate alloc;
+
+use alloc::rc::Rc;
+use core::{
+    cell::RefCell,
+    convert::Infallible,
+    ops::{Deref, DerefMut},
+};
+
+/// Read access to a stored value with potentially-fallible access.
+///
+/// Implementations that cannot fail use `Error = Infallible`.
+pub trait State {
+    /// The type of the stored value.
+    type Item: ?Sized;
+
+    /// Error type returned when access fails (e.g. paused, expired).
+    type Error: core::error::Error;
+
+    /// Borrow the stored value for reading.
+    fn read(&self) -> Result<impl Deref<Target = Self::Item>, Self::Error>;
+
+    /// Infallible shortcut for [`read`](Self::read).
+    ///
+    /// Available only when `Self::Error = Infallible`, so the unwrap below is
+    /// statically guaranteed to never panic — the only inhabitant of
+    /// `Result<_, Infallible>` reachable here is `Ok(_)`.
+    fn get(&self) -> impl Deref<Target = Self::Item>
+    where
+        Self: State<Error = Infallible>,
+    {
+        // `Error = Infallible` makes `Err(_)` uninhabited.
+        self.read().unwrap()
+    }
+}
+
+/// Mutable access to a stored value with potentially-fallible access.
+///
+/// `write` takes `&mut self`: idiomatic Rust mutation semantics. The
+/// implementation is free to use interior mutability (e.g. `RefCell`) so the
+/// underlying value need not be uniquely owned, but the caller must hold the
+/// state handle exclusively for the duration of the write.
+pub trait StateMut: State {
+    /// Borrow the stored value for writing.
+    fn write(&mut self) -> Result<impl DerefMut<Target = Self::Item>, Self::Error>;
+
+    /// Infallible shortcut for [`write`](Self::write).
+    ///
+    /// Available only when `Self::Error = Infallible`, so the unwrap below is
+    /// statically guaranteed to never panic — the only inhabitant of
+    /// `Result<_, Infallible>` reachable here is `Ok(_)`.
+    fn get_mut(&mut self) -> impl DerefMut<Target = Self::Item>
+    where
+        Self: StateMut<Error = Infallible>,
+    {
+        // `Error = Infallible` makes `Err(_)` uninhabited.
+        self.write().unwrap()
+    }
+
+    /// Replace the stored value, returning the previous one.
+    fn replace(&mut self, value: Self::Item) -> Result<Self::Item, Self::Error>
+    where
+        Self::Item: Sized,
+    {
+        let mut guard = self.write()?;
+        Ok(core::mem::replace(&mut *guard, value))
+    }
+
+    /// Replace the stored value with one produced by `f`, returning the previous one.
+    fn replace_with(
+        &mut self,
+        f: impl FnOnce(&mut Self::Item) -> Self::Item,
+    ) -> Result<Self::Item, Self::Error>
+    where
+        Self::Item: Sized,
+    {
+        let mut guard = self.write()?;
+        let replacement = f(&mut guard);
+        Ok(core::mem::replace(&mut *guard, replacement))
+    }
+
+    /// Take the stored value, leaving the default in its place.
+    fn take(&mut self) -> Result<Self::Item, Self::Error>
+    where
+        Self::Item: Default + Sized,
+    {
+        self.replace(Default::default())
+    }
+}
+
+// ---- Blanket impls for references ----
+
+/// `&S` is `State` whenever `S` is — read only requires shared access.
+impl<S: State + ?Sized> State for &S {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn read(&self) -> Result<impl Deref<Target = Self::Item>, Self::Error> {
+        S::read(*self)
+    }
+}
+
+/// `&mut S` is `State` whenever `S` is.
+impl<S: State + ?Sized> State for &mut S {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn read(&self) -> Result<impl Deref<Target = Self::Item>, Self::Error> {
+        S::read(&**self)
+    }
+}
+
+/// `&mut S` is `StateMut` whenever `S` is.
+///
+/// Note there is no equivalent blanket for `&S` — a shared reference cannot
+/// produce `&mut S` to forward through. Specific shared-ref impls (e.g.
+/// `&RefCell<T>` below) opt in directly via interior mutability.
+impl<S: StateMut + ?Sized> StateMut for &mut S {
+    fn write(&mut self) -> Result<impl DerefMut<Target = Self::Item>, Self::Error> {
+        S::write(&mut **self)
+    }
+}
+
+// ---- RefCell<T> ----
+
+impl<T: ?Sized> State for RefCell<T> {
+    type Item = T;
+    type Error = Infallible;
+
+    fn read(&self) -> Result<impl Deref<Target = T>, Infallible> {
+        Ok(self.borrow())
+    }
+}
+
+impl<T: ?Sized> StateMut for RefCell<T> {
+    fn write(&mut self) -> Result<impl DerefMut<Target = T>, Infallible> {
+        Ok(self.borrow_mut())
+    }
+}
+
+/// `&RefCell<T>` is `StateMut` directly — interior mutability lets a shared
+/// reference produce `&mut T` despite the trait's `&mut self` requirement.
+/// This is the canonical service-field type in the WASM static-state pattern.
+impl<T: ?Sized> StateMut for &RefCell<T> {
+    fn write(&mut self) -> Result<impl DerefMut<Target = T>, Infallible> {
+        Ok((*self).borrow_mut())
+    }
+}
+
+// ---- Rc<RefCell<T>> ----
+
+impl<T: ?Sized> State for Rc<RefCell<T>> {
+    type Item = T;
+    type Error = Infallible;
+
+    fn read(&self) -> Result<impl Deref<Target = T>, Infallible> {
+        Ok((**self).borrow())
+    }
+}
+
+impl<T: ?Sized> StateMut for Rc<RefCell<T>> {
+    fn write(&mut self) -> Result<impl DerefMut<Target = T>, Infallible> {
+        Ok((**self).borrow_mut())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+
+    // ---- RefCell<T> ----
+
+    #[test]
+    fn refcell_read_returns_value() {
+        let cell = RefCell::new(7u32);
+        assert_eq!(*cell.read().unwrap(), 7);
+    }
+
+    #[test]
+    fn refcell_write_mutates_value() {
+        let mut cell = RefCell::new(0u32);
+        *cell.write().unwrap() = 42;
+        assert_eq!(*cell.read().unwrap(), 42);
+    }
+
+    #[test]
+    fn refcell_replace_returns_old() {
+        let mut cell = RefCell::new(1u32);
+        // UFCS to disambiguate from inherent RefCell::replace.
+        let old = StateMut::replace(&mut cell, 2).unwrap();
+        assert_eq!(old, 1);
+        assert_eq!(*cell.read().unwrap(), 2);
+    }
+
+    #[test]
+    fn refcell_replace_with_transforms_value() {
+        let mut cell = RefCell::new(3u32);
+        let old = StateMut::replace_with(&mut cell, |v| *v * 10).unwrap();
+        assert_eq!(old, 3);
+        assert_eq!(*cell.read().unwrap(), 30);
+    }
+
+    #[test]
+    fn refcell_take_leaves_default() {
+        let mut cell = RefCell::new(99u32);
+        let taken = StateMut::take(&mut cell).unwrap();
+        assert_eq!(taken, 99);
+        assert_eq!(*cell.read().unwrap(), 0);
+    }
+
+    // ---- &RefCell<T> via direct StateMut impl ----
+
+    #[test]
+    fn shared_ref_to_refcell_can_write() {
+        let cell = RefCell::new(11u32);
+        let mut s: &RefCell<u32> = &cell;
+        assert_eq!(*s.read().unwrap(), 11);
+        *s.write().unwrap() = 12;
+        assert_eq!(*cell.read().unwrap(), 12);
+    }
+
+    #[test]
+    fn two_shared_refs_to_same_refcell_each_writable() {
+        // Distinct shared-reference handles can each be used as StateMut
+        // because mutation goes through the inner RefCell's interior mutability.
+        let cell = RefCell::new(0u32);
+        let mut a: &RefCell<u32> = &cell;
+        let mut b: &RefCell<u32> = &cell;
+        *a.write().unwrap() = 1;
+        *b.write().unwrap() = 2;
+        assert_eq!(*cell.read().unwrap(), 2);
+    }
+
+    // ---- Rc<RefCell<T>> ----
+
+    #[test]
+    fn rc_refcell_read_and_write() {
+        let mut s: Rc<RefCell<u32>> = Rc::new(RefCell::new(0));
+        *s.write().unwrap() = 5;
+        assert_eq!(*s.read().unwrap(), 5);
+    }
+
+    #[test]
+    fn rc_refcell_replace() {
+        let mut s: Rc<RefCell<u32>> = Rc::new(RefCell::new(1));
+        let old = StateMut::replace(&mut s, 9).unwrap();
+        assert_eq!(old, 1);
+        assert_eq!(*s.read().unwrap(), 9);
+    }
+
+    // ---- Generic over State / StateMut ----
+
+    fn read_doubled<S: State<Item = u32>>(s: &S) -> Result<u32, S::Error> {
+        Ok(*s.read()? * 2)
+    }
+
+    fn bump<S: StateMut<Item = u32>>(s: &mut S) -> Result<(), S::Error> {
+        *s.write()? += 1;
+        Ok(())
+    }
+
+    #[test]
+    fn generic_functions_work_with_refcell() {
+        let mut cell = RefCell::new(10u32);
+        assert_eq!(read_doubled(&cell).unwrap(), 20);
+        bump(&mut cell).unwrap();
+        assert_eq!(*cell.read().unwrap(), 11);
+    }
+
+    #[test]
+    fn generic_functions_work_with_rc_refcell() {
+        let mut s: Rc<RefCell<u32>> = Rc::new(RefCell::new(10));
+        assert_eq!(read_doubled(&s).unwrap(), 20);
+        bump(&mut s).unwrap();
+        assert_eq!(*s.read().unwrap(), 11);
+    }
+
+    #[test]
+    fn generic_functions_work_with_shared_ref_to_refcell() {
+        let cell = RefCell::new(10u32);
+        let mut s: &RefCell<u32> = &cell;
+        assert_eq!(read_doubled(&s).unwrap(), 20);
+        bump(&mut s).unwrap();
+        assert_eq!(*cell.read().unwrap(), 11);
+    }
+
+    // ---- Service-style usage (the motivating pattern) ----
+
+    struct CounterService<'a, S: StateMut<Item = u32, Error = Infallible> = &'a RefCell<u32>> {
+        counter: S,
+        _phantom: core::marker::PhantomData<&'a ()>,
+    }
+
+    impl<'a, S: StateMut<Item = u32, Error = Infallible>> CounterService<'a, S> {
+        fn new(counter: S) -> Self {
+            Self {
+                counter,
+                _phantom: core::marker::PhantomData,
+            }
+        }
+
+        // Mutation requires &mut self — idiomatic.
+        fn increment(&mut self) {
+            *self.counter.get_mut() += 1;
+        }
+
+        // Reads stay on &self.
+        fn value(&self) -> u32 {
+            *self.counter.get()
+        }
+    }
+
+    #[test]
+    fn service_with_refcell_default() {
+        let cell = RefCell::new(0u32);
+        let mut svc = CounterService::new(&cell);
+        svc.increment();
+        svc.increment();
+        svc.increment();
+        assert_eq!(svc.value(), 3);
+        assert_eq!(*cell.read().unwrap(), 3);
+    }
+
+    // ---- Composition example: a fallible wrapper ----
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum GatedError<E> {
+        Closed,
+        Inner(E),
+    }
+
+    impl<E: core::fmt::Display> core::fmt::Display for GatedError<E> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match self {
+                GatedError::Closed => f.write_str("gated: closed"),
+                GatedError::Inner(e) => write!(f, "gated: {}", e),
+            }
+        }
+    }
+
+    impl<E: core::error::Error> core::error::Error for GatedError<E> {}
+
+    struct Gated<'g, S> {
+        inner: S,
+        open: &'g core::cell::Cell<bool>,
+    }
+
+    impl<'g, S: State> State for Gated<'g, S> {
+        type Item = S::Item;
+        type Error = GatedError<S::Error>;
+
+        fn read(&self) -> Result<impl Deref<Target = Self::Item>, Self::Error> {
+            self.inner.read().map_err(GatedError::Inner)
+        }
+    }
+
+    impl<'g, S: StateMut> StateMut for Gated<'g, S> {
+        fn write(&mut self) -> Result<impl DerefMut<Target = Self::Item>, Self::Error> {
+            if !self.open.get() {
+                return Err(GatedError::Closed);
+            }
+            self.inner.write().map_err(GatedError::Inner)
+        }
+    }
+
+    #[test]
+    fn gated_blocks_writes_when_closed() {
+        let cell = RefCell::new(0u32);
+        let open = core::cell::Cell::new(true);
+        let mut gated = Gated {
+            inner: &cell,
+            open: &open,
+        };
+
+        *gated.write().unwrap() = 5;
+        assert_eq!(*gated.read().unwrap(), 5);
+
+        open.set(false);
+        assert!(matches!(gated.write(), Err(GatedError::Closed)));
+        // Reads still work.
+        assert_eq!(*gated.read().unwrap(), 5);
+    }
+}


### PR DESCRIPTION
Two traits for abstracting over state storage:

- `State` — read access; `read(&self) -> Result<impl Deref<Target = Item>, Error>`
- `StateMut: State` — write access; `write(&mut self) -> Result<impl DerefMut<Target = Item>, Error>`
