### PR TITLE
feat: Simplify service event listening API

### DIFF
--- a/examples/demo/app/tests/gclient.rs
+++ b/examples/demo/app/tests/gclient.rs
@@ -32,8 +32,7 @@ async fn counter_add_works() {
 
     let mut counter_client = demo_program.counter();
     // Listen to Counter events
-    let counter_listener = counter_client.listener();
-    let mut counter_events = counter_listener.listen().await.unwrap();
+    let mut counter_events = counter_client.listen().await.unwrap();
 
     // Act
 
@@ -75,8 +74,7 @@ async fn counter_sub_works() {
 
     let mut counter_client = demo_program.counter();
     // Listen to Counter events
-    let counter_listener = counter_client.listener();
-    let mut counter_events = counter_listener.listen().await.unwrap();
+    let mut counter_events = counter_client.listen().await.unwrap();
 
     // Act
 

--- a/examples/demo/app/tests/gtest.rs
+++ b/examples/demo/app/tests/gtest.rs
@@ -45,8 +45,7 @@ async fn counter_add_works() {
 
     let mut counter_client = demo_program.counter();
     // Listen to Counter events
-    let counter_listener = counter_client.listener();
-    let mut counter_events = counter_listener.listen().await.unwrap();
+    let mut counter_events = counter_client.listen().await.unwrap();
 
     // Act
 
@@ -78,8 +77,7 @@ async fn counter_sub_works() {
 
     let mut counter_client = demo_program.counter();
     // Listen to Counter events
-    let counter_listener = counter_client.listener();
-    let mut counter_events = counter_listener.listen().await.unwrap();
+    let mut counter_events = counter_client.listen().await.unwrap();
 
     // Act
 
@@ -223,8 +221,7 @@ async fn dog_barks() {
         .unwrap();
 
     let mut dog_client = demo_program.dog();
-    let dog_listener = dog_client.listener();
-    let mut dog_events = dog_listener.listen().await.unwrap();
+    let mut dog_events = dog_client.listen().await.unwrap();
 
     // Act
     let result = dog_client.make_sound().await.unwrap();
@@ -255,8 +252,7 @@ async fn dog_walks() {
 
     let dog_client = demo_program.dog();
     let mut walker_client = dog_client.walker_service();
-    let listener = walker_client.listener();
-    let mut events = listener.listen().await.unwrap();
+    let mut events = walker_client.listen().await.unwrap();
 
     // Act
     walker_client.walk(10, 20).await.unwrap();
@@ -390,8 +386,7 @@ async fn counter_add_works_via_next_mode() {
 
     let mut counter_client = demo_program.counter();
     // Listen to Counter events
-    let counter_listener = counter_client.listener();
-    let mut counter_events = counter_listener.listen().await.unwrap();
+    let mut counter_events = counter_client.listen().await.unwrap();
 
     // Act
     let result = counter_client.add(10).await.unwrap();
@@ -424,8 +419,7 @@ async fn counter_add_works_via_manual_mode() {
 
     let mut counter_client = demo_program.counter();
     // Listen to Counter events
-    let counter_listener = counter_client.listener();
-    let mut counter_events = counter_listener.listen().await.unwrap();
+    let mut counter_events = counter_client.listen().await.unwrap();
 
     // Use generated client code for calling Counter service
     let call_add = counter_client.add(10).send_for_reply().unwrap();

--- a/examples/partial-idl/app/tests/gtest.rs
+++ b/examples/partial-idl/app/tests/gtest.rs
@@ -40,8 +40,7 @@ async fn test_partial_client_subscribes_to_third_event() {
     let (env, code_id) = create_env();
     let program = env.deploy(code_id, vec![]).new().await.unwrap();
     let mut client = program.partial_idl_service();
-    let listener = client.listener();
-    let mut events = listener.listen().await.unwrap();
+    let mut events = client.listen().await.unwrap();
     client.third().await.unwrap();
     let event = events.next().await.unwrap();
     assert_eq!(

--- a/rs/client-gen/tests/demo_gtest.rs
+++ b/rs/client-gen/tests/demo_gtest.rs
@@ -75,8 +75,7 @@ async fn counter_add_works() {
         .unwrap();
 
     let mut counter_client = demo_program.counter();
-    let listener = counter_client.listener();
-    let mut events = listener.listen().await.unwrap();
+    let mut events = counter_client.listen().await.unwrap();
 
     let result = counter_client.add(10).await.unwrap();
 
@@ -119,8 +118,7 @@ async fn dog_barks() {
         .unwrap();
 
     let mut dog_client = demo_program.dog();
-    let listener = dog_client.listener();
-    let mut events = listener.listen().await.unwrap();
+    let mut events = dog_client.listen().await.unwrap();
 
     let result = dog_client.make_sound().await.unwrap();
 
@@ -144,8 +142,7 @@ async fn dog_walks() {
         .unwrap();
 
     let mut dog_client = demo_program.dog();
-    let listener = dog_client.listener();
-    let mut events = listener.listen().await.unwrap();
+    let mut events = dog_client.listen().await.unwrap();
 
     dog_client.walk(10, 20).await.unwrap();
 

--- a/rs/src/client/gclient_env.rs
+++ b/rs/src/client/gclient_env.rs
@@ -230,7 +230,7 @@ impl Listener for GclientEnv {
     async fn listen<E, F: FnMut((ActorId, Vec<u8>)) -> Option<(ActorId, E)>>(
         &self,
         f: F,
-    ) -> Result<impl Stream<Item = (ActorId, E)> + Unpin, Self::Error> {
+    ) -> Result<impl Stream<Item = (ActorId, E)> + Unpin + use<E, F>, Self::Error> {
         let listener = self.api.subscribe().await?;
         let stream = stream::unfold(listener, |mut l| async move {
             let vec = get_events_from_block(&mut l).await.ok();

--- a/rs/src/client/gtest_env.rs
+++ b/rs/src/client/gtest_env.rs
@@ -472,7 +472,7 @@ impl Listener for GtestEnv {
     async fn listen<E, F: FnMut((ActorId, Vec<u8>)) -> Option<(ActorId, E)>>(
         &self,
         f: F,
-    ) -> Result<impl Stream<Item = (ActorId, E)> + Unpin, Self::Error> {
+    ) -> Result<impl Stream<Item = (ActorId, E)> + Unpin + use<E, F>, Self::Error> {
         let (tx, rx) = mpsc::unbounded::<(ActorId, Vec<u8>)>();
         self.event_senders.borrow_mut().push(tx);
         Ok(rx.filter_map(f))

--- a/rs/src/client/mod.rs
+++ b/rs/src/client/mod.rs
@@ -212,11 +212,25 @@ impl<S, E: GearEnv, R: RouteHeader> Service<S, E, R> {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn listener(&self) -> ServiceListener<S::Event, E, R>
+    pub async fn listen(
+        &self,
+    ) -> Result<impl Stream<Item = (ActorId, S::Event)> + Unpin + use<S, E, R>, <E as GearEnv>::Error>
     where
         S: ServiceWithEvents<R>,
+        E: Listener<Error = <E as GearEnv>::Error>,
     {
-        ServiceListener::new(self.env.clone(), self.actor_id, self.route.clone())
+        let self_id = self.actor_id;
+        let route = self.route.clone();
+        self.env
+            .listen(move |(actor_id, payload)| {
+                if actor_id != self_id {
+                    return None;
+                }
+                S::Event::decode_event(&route, payload)
+                    .ok()
+                    .map(|e| (actor_id, e))
+            })
+            .await
     }
 }
 
@@ -237,44 +251,6 @@ impl<S, E: GearEnv> Service<S, E, RouteIdx> {
 #[cfg(not(target_arch = "wasm32"))]
 pub trait ServiceWithEvents<R: RouteHeader = RouteIdx> {
     type Event: Event<R>;
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub struct ServiceListener<D: Event<R>, E: GearEnv = GstdEnv, R: RouteHeader = RouteIdx> {
-    env: E,
-    actor_id: ActorId,
-    route: R,
-    _phantom: PhantomData<D>,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<D: Event<R>, E: GearEnv, R: RouteHeader> ServiceListener<D, E, R> {
-    pub fn new(env: E, actor_id: ActorId, route: R) -> Self {
-        ServiceListener {
-            env,
-            actor_id,
-            route,
-            _phantom: PhantomData,
-        }
-    }
-
-    pub async fn listen(
-        &self,
-    ) -> Result<impl Stream<Item = (ActorId, D)> + Unpin, <E as GearEnv>::Error>
-    where
-        E: Listener<Error = <E as GearEnv>::Error>,
-    {
-        let self_id = self.actor_id;
-        let route = self.route.clone();
-        self.env
-            .listen(move |(actor_id, payload)| {
-                if actor_id != self_id {
-                    return None;
-                }
-                D::decode_event(&route, payload).ok().map(|e| (actor_id, e))
-            })
-            .await
-    }
 }
 
 pin_project_lite::pin_project! {
@@ -820,7 +796,7 @@ pub trait Listener {
     async fn listen<E, F>(
         &self,
         f: F,
-    ) -> Result<impl Stream<Item = (ActorId, E)> + Unpin, Self::Error>
+    ) -> Result<impl Stream<Item = (ActorId, E)> + Unpin + use<Self, E, F>, Self::Error>
     where
         F: FnMut((ActorId, Vec<u8>)) -> Option<(ActorId, E)>;
 }


### PR DESCRIPTION
## Summary
- Replace the `Service::listener().listen().await` flow with direct `Service::listen().await`
- Remove the intermediate `ServiceListener` type
- Update `gtest` and `gclient` listener return types with explicit `use<...>` captures
- Update demo, partial IDL, and client-gen tests to use the new direct listener API
