### PR TITLE
fix: drop `gclient` from default `cargo sails new` dev-deps

### DIFF
--- a/rs/cli/README.md
+++ b/rs/cli/README.md
@@ -84,7 +84,7 @@ The `cargo sails new` command creates a workspace with a few distinct parts:
   implementation.
 - `client` crate: the package that builds the generated Rust client interface
   for interacting with the program.
-- `tests` directory: integration tests based on `gtest`/`gclient`.
+- `tests` directory: integration tests based on `gtest` (opt into `gclient` for live-node tests).
 
 Typical generated-project workflow:
 

--- a/rs/cli/src/program_new.rs
+++ b/rs/cli/src/program_new.rs
@@ -449,9 +449,9 @@ impl ProgramGenerator {
             manifest_path,
             Development,
             Some(if self.ethereum {
-                "ethexe,gtest,gclient"
+                "ethexe,gtest"
             } else {
-                "gtest,gclient"
+                "gtest"
             }),
         )?;
 

--- a/rs/cli/templates/readme.askama
+++ b/rs/cli/templates/readme.askama
@@ -22,6 +22,12 @@ cargo build --release
 cargo test --release
 ```
 
+> For off-chain integration tests against a running node, add the `gclient` feature:
+>
+> ```bash
+> cargo add sails-rs --dev --features gclient
+> ```
+
 # License
 
 The source code is licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
## Summary

- Drop `gclient` from the default dev-dep feature list in `cargo sails new`-scaffolded projects (`rs/cli/src/program_new.rs`).
- Add an opt-in note in the scaffold README pointing builders at `cargo add sails-rs --dev --features gclient` for live-node tests.
- Update `rs/cli/README.md` to match.

## Context

Issue #1334 (Issue 1) reports that fresh-scaffold builds drag in a heavy substrate / subxt / sp-core / jsonrpsee tree via `gclient`, which the default tests do not use. The reporter's specific resolution-failure claim (`subxt 0.44.0 doesn't exist`) was inaccurate — `subxt 0.44.0–0.44.3` have been published since 2025-08-29 and resolve cleanly today — but the underlying complaint about scaffold weight and surface area for misdiagnosis is legitimate.

The default `tests/gtest.askama` only uses `GtestEnv` and `DEFAULT_USER_ALICE` from `sails_rs::gtest`. There is no `gclient` reference anywhere in the generated project. `gclient` is dead weight unless the builder later writes off-chain RPC tests against a live node.

## Impact

Measured on a freshly scaffolded `cargo sails new sails-fix-check`:

| metric | before | after | delta |
|---|---:|---:|---:|
| Cargo.lock packages | 818 | 697 | −121 |
| Cargo.lock lines | 8928 | 7405 | −1523 |
| `cargo tree` references to `gclient`/`subxt`/`gsdk` | many | 0 | — |

## Test plan

- [x] `cargo build -p sails-cli --release`
- [x] `cargo clippy -p sails-cli --all-targets --locked -- -D warnings` (clean)
- [x] `cargo sails new <name>` and confirm scaffolded `[dev-dependencies] sails-rs` shows `features = ["gtest"]` only
- [x] `cargo tree` on the scaffolded project shows no `gclient` / `subxt` / `gsdk`
- [x] Generated README contains the `gclient` opt-in note
- [ ] CI green

## Out of scope

This PR addresses Issue 1 from #1334 only. Issues 2 (`ReflectHash` boilerplate) and 3 (`msg::source` import) are tracked separately. There is also an unrelated `StateMut`/`Infallible` build failure on master from a version skew between the published `sails-rs 1.0.0-beta.4` prelude and the post-#1331 master prelude — not addressed here.

Refs #1334

🤖 Generated with [Claude Code](https://claude.com/claude-code)