### PR TITLE
chore: Clarify service-local IDL type scopes

### DIFF
--- a/docs/idl-v2-spec.md
+++ b/docs/idl-v2-spec.md
@@ -220,6 +220,16 @@ service <ident> {
 }
 ```
 
+Service IDL is self-contained. Types referenced by service functions, events,
+and `throws` declarations are resolved from the service's own `types` block and
+from explicitly extended service interfaces. Program-level `types` are not an
+ambient scope for services, so a service can be distributed independently from a
+particular program definition.
+
+Program-level `types` are available to program constructors and other
+program-level declarations. A program may expose services through `services`,
+but that does not make program-local types visible inside those services.
+
 ### Service Events
 
 Service event is represented as an enum variant with an associated payload.
@@ -417,4 +427,5 @@ program DemoCanvas {
 > 1. `extends` merge `events`, `functions` and `types` with service declaration according to
 >    - `functions` override decalaration (TBD)
 > 2. Namespaces are not included in the specification
->    - reference to service type `<service_ident>::<type_ident>` (TBD)
+>    - reference to service type `<service_ident>::<type_ident>` from program/root scopes (TBD)
+>    - service declarations do not implicitly resolve names from `program.types`

--- a/js/test/idl-v2-parser-type-resolver.test.ts
+++ b/js/test/idl-v2-parser-type-resolver.test.ts
@@ -341,3 +341,73 @@ describe('type-resolver-v2 generics', () => {
     ).toEqual({ three: { p1: arrayTupleU8, p2: [['a', 'b', 'c', 'd'], null] } });
   });
 });
+
+describe('type-resolver-v2 service scopes', () => {
+  test('service resolver does not see program-level types', () => {
+    const text = `
+      !@sails: 1.0.0-beta.3
+
+      service A {
+        functions {
+          Ping() -> u32;
+        }
+      }
+
+      program Test {
+        constructors {
+          Default(shared: Shared);
+        }
+        services {
+          A,
+        }
+        types {
+          struct Shared {
+            v: u32,
+          }
+        }
+      }
+    `;
+
+    const program = new SailsProgram(parser.parse(text));
+    const service = program.services['A'];
+
+    expect(service.registry.hasType('Shared')).toBe(false);
+  });
+
+  test('service-local types shadow same-named program types', () => {
+    const text = `
+      !@sails: 1.0.0-beta.3
+
+      service A {
+        functions {
+          UseShared(input: Shared);
+        }
+        types {
+          struct Shared {
+            service_value: String,
+          }
+        }
+      }
+
+      program Test {
+        constructors {
+          Default(shared: Shared);
+        }
+        services {
+          A,
+        }
+        types {
+          struct Shared {
+            program_value: u32,
+          }
+        }
+      }
+    `;
+
+    const program = new SailsProgram(parser.parse(text));
+    const service = program.services['A'];
+    const encoded = service.registry.createType('Shared', { service_value: 'local' });
+
+    expect(encoded.toJSON()).toEqual({ service_value: 'local' });
+  });
+});

--- a/rs/client-gen-v2/tests/idls/scope_test.idl
+++ b/rs/client-gen-v2/tests/idls/scope_test.idl
@@ -22,13 +22,13 @@ program MyProgram {
 
 service MyService {
     functions {
-        /// Uses CommonType from program scope.
+        /// Uses the service-local CommonType.
         DoSomething(input: CommonType) -> u32;
 
         /// Uses CommonType from service scope.
         AnotherAction(input: ServiceCommonType) -> u32;
 
-        /// TBD: Uses ProgramOnlyType from program scope.
+        /// Uses the service-local ProgramOnlyType.
         UseProgramType(input: ProgramOnlyType) -> bool;
     }
 

--- a/rs/client-gen-v2/tests/snapshots/generator__scope_resolution.snap
+++ b/rs/client-gen-v2/tests/snapshots/generator__scope_resolution.snap
@@ -82,12 +82,12 @@ pub mod my_service {
             &mut self,
             input: ServiceCommonType,
         ) -> sails_rs::client::PendingCall<io::AnotherAction, Self::Env>;
-        /// Uses CommonType from program scope.
+        /// Uses the service-local CommonType.
         fn do_something(
             &mut self,
             input: CommonType,
         ) -> sails_rs::client::PendingCall<io::DoSomething, Self::Env>;
-        /// TBD: Uses ProgramOnlyType from program scope.
+        /// Uses the service-local ProgramOnlyType.
         fn use_program_type(
             &mut self,
             input: ProgramOnlyType,

--- a/rs/idl-parser-v2/src/post_process.rs
+++ b/rs/idl-parser-v2/src/post_process.rs
@@ -26,36 +26,36 @@ const ALLOWED_TYPES: &[&str] = &[
 pub fn validate_and_post_process(doc: &mut IdlDoc) -> Result<()> {
     normalize_generics(doc);
 
-    let mut validator = Validator::new();
+    let mut errors = Vec::new();
 
-    // 1. Program types are added to the root scope so they remain visible to all services.
+    // Program types are scoped to the program unit. Service IDL stays
+    // self-contained and is validated with its own named type scope.
     if let Some(program) = &doc.program {
+        let mut validator = Validator::new();
         for ty in &program.types {
             validator.add_named_type(&ty.name);
         }
-        // 2. Validate the program unit (ctors, type references, field consistency).
         validator.visit_program_unit(program);
+        errors.extend(validator.errors);
     }
 
-    // 3. Validate each service unit (funcs, events, types, field consistency).
+    // Validate each service unit (funcs, events, types, field consistency).
     for service in &doc.services {
+        let mut validator = Validator::new();
         validator.visit_service_unit(service);
+        errors.extend(validator.errors);
     }
 
-    // 4. Collect and return any validation errors found above.
-    if !validator.errors.is_empty() {
-        let error_messages: Vec<String> = validator
-            .errors
-            .into_iter()
-            .map(|e| e.to_string())
-            .collect();
+    // Collect and return any validation errors found above.
+    if !errors.is_empty() {
+        let error_messages: Vec<String> = errors.into_iter().map(|e| e.to_string()).collect();
         return Err(Error::Validation(error_messages.join("\n")));
     }
 
-    // 5. Validate entry_ids: check uniqueness and that @partial services have explicit @entry_id.
+    // Validate entry_ids: check uniqueness and that @partial services have explicit @entry_id.
     validate_entry_ids(doc)?;
 
-    // 6. Compute and assign `interface_id` for each service.
+    // Compute and assign `interface_id` for each service.
     let mut service_ids = ServiceInterfaceId::new(doc);
     service_ids.update_service_id()?;
 

--- a/rs/idl-parser-v2/tests/idls/post_process_advanced_scoping.idl
+++ b/rs/idl-parser-v2/tests/idls/post_process_advanced_scoping.idl
@@ -14,8 +14,7 @@ program ScopingProgram {
 service ServiceA {
     types {
         struct TypeA {
-            // Valid: uses a type from the "parent" program scope
-            root: RootType, 
+            val: u32,
         }
     }
     functions {

--- a/rs/idl-parser-v2/tests/post_process.rs
+++ b/rs/idl-parser-v2/tests/post_process.rs
@@ -33,6 +33,31 @@ fn validate_scoping_fails_on_sibling_service_type_usage() {
     let err = result.expect_err("Should have failed due to sibling service type usage");
     assert!(err.to_string().contains("Unknown type 'TypeX'"));
 }
+
+#[test]
+fn validate_named_types_fails_on_program_type_in_service() {
+    let src = r#"
+        program P {
+            types {
+                struct ProgramType { val: u32 }
+            }
+            services {
+                S: S,
+            }
+        }
+
+        service S {
+            functions {
+                UseProgramType(input: ProgramType);
+            }
+        }
+    "#;
+
+    let err =
+        parse_idl(src).expect_err("Should have failed due to program type used in service scope");
+    assert!(err.to_string().contains("Unknown type 'ProgramType'"));
+}
+
 #[test]
 fn validate_mixed_fields_fails() {
     let src = include_str!("idls/post_process_mixed_fields.idl");


### PR DESCRIPTION
This clarifies the IDL type-scope boundary around service self-containment.

The intended model is that `program.types` are scoped to program-level declarations such as constructors, while service functions/events/throws resolve their payload types from the service’s own `types` and explicitly extended service interfaces. `program.types` are not an ambient scope for services, so a service IDL can be distributed and consumed independently from any particular program IDL.

`extends` remains the service-to-service dependency mechanism: it references another service interface by `ServiceIdent`/`interface_id`, not by the enclosing program. The namespace TBD is clarified as future `Service::Type` support from program/root scopes, not as service-to-program fallback.

The parser validation now enforces that split, and the JS/client-gen tests document the expected service-local behavior and shadowing.
