### PR TITLE
feat(js): public user-type accessors on SailsProgram and SailsService

### DIFF
--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -22,7 +22,10 @@
 - Added: top-level `sails-js` entry now re-exports the v2 IDL AST typings
   (`Type`, `TypeDecl`, `ITypeStruct`, `ITypeEnum`, `ITypeAlias`, `IIdlDoc`,
   `IServiceUnit`, etc.) so consumers can `import type { Type } from 'sails-js'`
-  without reaching for the `sails-js/types` subpath.
+  without reaching for the `sails-js/types` subpath. The re-export resolves
+  to the bundled `lib/types.d.ts` (which already inlines `sails-js-types`
+  via the rollup `dts` step), so consumers do not need `sails-js-types` —
+  a private workspace package — installed.
 
 ## 0.5.1
 

--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -12,6 +12,17 @@
 - Documented the `sails-js/types`, `sails-js/parser`, and `sails-js/util` subpath
   exports in the README, which re-export types from the internal `sails-js-types`,
   `sails-js-parser-idl-v2`, and `sails-js-util` packages.
+- Added: `SailsProgram.programTypes` and `SailsService.types` — public
+  `ReadonlyMap<string, Type>` accessors for the user types declared in the v2
+  IDL's `program {…}` block and in each service's own `types {…}` block.
+  `SailsService.types` is declared-only; for the merged extends-chain scope use
+  `program.resolveInService` or walk `service.extends`. Both maps are empty
+  when the corresponding IDL block is absent. Treat as immutable: the type
+  blocks `.set()` at compile time, runtime is not enforced.
+- Added: top-level `sails-js` entry now re-exports the v2 IDL AST typings
+  (`Type`, `TypeDecl`, `ITypeStruct`, `ITypeEnum`, `ITypeAlias`, `IIdlDoc`,
+  `IServiceUnit`, etc.) so consumers can `import type { Type } from 'sails-js'`
+  without reaching for the `sails-js/types` subpath.
 
 ## 0.5.1
 

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -9,4 +9,4 @@ export { TransactionBuilderWithHeader } from './transaction-builder-with-header.
 export { IMethodReturnType, TransactionBuilder } from './transaction-builder.js';
 export { TypeResolver } from './type-resolver-idl-v2.js';
 export { throwOnErrorReply } from './utils.js';
-export type * from 'sails-js-types';
+export type * from './types.js';

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -9,3 +9,4 @@ export { TransactionBuilderWithHeader } from './transaction-builder-with-header.
 export { IMethodReturnType, TransactionBuilder } from './transaction-builder.js';
 export { TypeResolver } from './type-resolver-idl-v2.js';
 export { throwOnErrorReply } from './utils.js';
+export type * from 'sails-js-types';

--- a/js/src/sails-idl-v2.ts
+++ b/js/src/sails-idl-v2.ts
@@ -23,6 +23,7 @@ interface ISailsService {
   readonly events: Record<string, ISailsServiceEvent>;
   readonly extends: Record<string, SailsService>;
   readonly routeIdx: number;
+  readonly types: ReadonlyMap<string, Type>;
 }
 
 interface ISailsFuncArg {

--- a/js/src/sails-idl-v2.ts
+++ b/js/src/sails-idl-v2.ts
@@ -170,6 +170,7 @@ export class SailsProgram {
   private _api?: GearApi;
   private _programId?: HexString;
   private _services: Map<bigint, IServiceUnit>;
+  private readonly _programTypes: ReadonlyMap<string, Type>;
   // Lazy index for resolveInService: per-service `Map<typeName, Type>`, pre-merged
   // with the service's transitive extends chain. Populated on first call; not
   // invalidated because `_doc` is immutable after parse.
@@ -191,6 +192,7 @@ export class SailsProgram {
     if (this._doc.program) {
       this._typeResolver = new TypeResolver(this._doc.program.types ?? []);
     }
+    this._programTypes = new Map((doc.program?.types ?? []).map((t) => [t.name, t]));
     this._services = this._initServices();
   }
 
@@ -241,6 +243,21 @@ export class SailsProgram {
     }
 
     return this._typeResolver;
+  }
+
+  /**
+   * Program-level user types declared in the IDL's `program {…}` block,
+   * keyed by type name.
+   *
+   * These are ambient: visible to every service and to constructors. Returns
+   * an empty `Map` when the IDL has no `program {…}` block (services-only
+   * IDL) or when the program block has no `types`.
+   *
+   * Treat as immutable. The `ReadonlyMap` type blocks `.set()` at the type
+   * level; runtime mutation is not enforced.
+   */
+  get programTypes(): ReadonlyMap<string, Type> {
+    return this._programTypes;
   }
 
   /** #### Services with functions and events from the parsed IDL */
@@ -418,6 +435,7 @@ export class SailsService implements ISailsService {
   private _typeResolver: TypeResolver;
   private _api?: GearApi;
   private _routeIdx: number;
+  private readonly _types: ReadonlyMap<string, Type>;
 
   private _resolveServiceUnit?: (ident: IServiceIdent) => IServiceUnit | undefined;
 
@@ -434,6 +452,7 @@ export class SailsService implements ISailsService {
     this._resolveServiceUnit = resolveServiceUnit;
     // Self-contained scope: bases first so locals shadow on collision.
     this._typeResolver = new TypeResolver(_collectServiceScopeTypes(service, resolveServiceUnit));
+    this._types = new Map((service.types ?? []).map((t) => [t.name, t]));
     this._routeIdx = routeIdx;
 
     this.events = this._getEvents(service);
@@ -481,6 +500,24 @@ export class SailsService implements ISailsService {
   /** #### TypeResolver with registered types from the ServiceUnit */
   get typeResolver() {
     return this._typeResolver;
+  }
+
+  /**
+   * User types declared in *this service's own* IDL `types {…}` block,
+   * keyed by type name.
+   *
+   * Declared-only: this map does not include types inherited from base
+   * services via `extends`. To enumerate the transitive scope, walk
+   * `.extends[base].types`; to resolve a single `TypeDecl` against the full
+   * scope, call `program.resolveInService(serviceName, decl)`.
+   *
+   * Returns an empty `Map` when the service has no `types {…}` block.
+   *
+   * Treat as immutable. The `ReadonlyMap` type blocks `.set()` at the type
+   * level; runtime mutation is not enforced.
+   */
+  get types(): ReadonlyMap<string, Type> {
+    return this._types;
   }
 
   private _getFunctions(service: IServiceUnit): {

--- a/js/test/idl-v2-types-accessors.test.ts
+++ b/js/test/idl-v2-types-accessors.test.ts
@@ -1,0 +1,285 @@
+import { SailsIdlParser } from 'sails-js-parser-idl-v2';
+
+import { SailsProgram, type ITypeStruct, type Type } from '..';
+
+let parser: SailsIdlParser;
+
+beforeAll(async () => {
+  parser = new SailsIdlParser();
+  await parser.init();
+});
+
+describe('SailsProgram.programTypes', () => {
+  test('returns a map of program-level user types keyed by name', () => {
+    const text = `
+      program Test {
+        types {
+          struct Shared {
+            v: u32,
+          }
+          enum Mood {
+            Happy,
+            Sad,
+          }
+        }
+        constructors {
+          Default(p: Shared);
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+
+    expect(program.programTypes.size).toBe(2);
+
+    const shared = program.programTypes.get('Shared');
+    expect(shared?.kind).toBe('struct');
+    expect((shared as ITypeStruct).fields).toHaveLength(1);
+
+    const mood = program.programTypes.get('Mood');
+    expect(mood?.kind).toBe('enum');
+  });
+
+  test('returns an empty map when the program block has no types', () => {
+    const text = `
+      program Test {
+        constructors {
+          Default();
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+
+    expect(program.programTypes.size).toBe(0);
+  });
+
+  test('returns an empty map when the IDL has no program block', () => {
+    // Services-only IDL: legal per the v2 spec for service interface bundles.
+    const text = `
+      !@sails: 1.0.0-beta.3
+
+      service Foo {
+        functions {
+          Ping() -> u32;
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+
+    expect(program.programTypes.size).toBe(0);
+  });
+
+  test('returns the same Map instance on repeated access (eager construction)', () => {
+    const text = `
+      program Test {
+        types {
+          struct A { v: u32 }
+        }
+        constructors {
+          Default();
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+
+    expect(program.programTypes).toBe(program.programTypes);
+  });
+});
+
+describe('SailsService.types', () => {
+  test('returns a map of types declared in the service block', () => {
+    const text = `
+      !@sails: 1.0.0-beta.3
+
+      service Foo {
+        functions {
+          Ping() -> Local;
+        }
+        types {
+          struct Local {
+            v: u32,
+          }
+        }
+      }
+
+      program Test {
+        constructors {
+          Default();
+        }
+        services {
+          Foo,
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+    const foo = program.services.Foo;
+
+    expect(foo.types.size).toBe(1);
+    expect(foo.types.get('Local')?.kind).toBe('struct');
+  });
+
+  test('returns an empty map when the service has no types block', () => {
+    const text = `
+      !@sails: 1.0.0-beta.3
+
+      service Foo {
+        functions {
+          Ping() -> u32;
+        }
+      }
+
+      program Test {
+        constructors {
+          Default();
+        }
+        services {
+          Foo,
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+
+    expect(program.services.Foo.types.size).toBe(0);
+  });
+
+  test('declared-only: types declared in service A are not in service B.types', () => {
+    const text = `
+      !@sails: 1.0.0-beta.3
+
+      service Alpha {
+        functions {
+          Ping() -> InAlpha;
+        }
+        types {
+          struct InAlpha {
+            v: u32,
+          }
+        }
+      }
+
+      service Beta {
+        functions {
+          Ping() -> InBeta;
+        }
+        types {
+          struct InBeta {
+            w: u32,
+          }
+        }
+      }
+
+      program Test {
+        constructors {
+          Default();
+        }
+        services {
+          Alpha,
+          Beta,
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+
+    expect(program.services.Alpha.types.has('InAlpha')).toBe(true);
+    expect(program.services.Alpha.types.has('InBeta')).toBe(false);
+
+    expect(program.services.Beta.types.has('InBeta')).toBe(true);
+    expect(program.services.Beta.types.has('InAlpha')).toBe(false);
+  });
+
+  test('declared-only: base types are not pulled into the derived service via extends', () => {
+    // `Child` extends `Base`. `Base` defines `Shared`. The declared-only contract
+    // says `Child.types` must NOT include `Shared` — that's only reachable via
+    // `Child.extends.Base.types` or `program.resolveInService('Child', ...)`.
+    const text = `
+      !@sails: 1.0.0-beta.3
+
+      service Base {
+        functions {
+          Ping() -> u32;
+        }
+        types {
+          struct Shared {
+            v: u32,
+          }
+        }
+      }
+
+      service Child {
+        extends {
+          Base,
+        }
+      }
+
+      program Test {
+        constructors {
+          Default();
+        }
+        services {
+          Child,
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+    const child = program.services.Child;
+
+    expect(child.types.size).toBe(0);
+    expect(child.types.has('Shared')).toBe(false);
+
+    // Sanity check: the base type is reachable via the extends accessor.
+    expect(child.extends.Base.types.has('Shared')).toBe(true);
+
+    // Sanity check: resolveInService still merges the extends chain.
+    const resolved = program.resolveInService('Child', { kind: 'named', name: 'Shared' });
+    expect(resolved?.kind).toBe('struct');
+  });
+
+  test('returns the same Map instance on repeated access (eager construction)', () => {
+    const text = `
+      !@sails: 1.0.0-beta.3
+
+      service Foo {
+        functions { Ping() -> u32; }
+        types {
+          struct Local { v: u32 }
+        }
+      }
+
+      program Test {
+        constructors {
+          Default();
+        }
+        services {
+          Foo,
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+    const foo = program.services.Foo;
+
+    expect(foo.types).toBe(foo.types);
+  });
+});
+
+describe('top-level type re-export from sails-js', () => {
+  test('AST types `Type` and `ITypeStruct` import from the package root', () => {
+    // Type-level proof: this file imports `Type` and `ITypeStruct` from `'..'`
+    // (the sails-js root entry, not the `./types` subpath). If the re-export
+    // were missing, the imports above and the assignment below would not
+    // compile — jest's TS pass exercises the check at test build time.
+    const text = `
+      program Test {
+        types {
+          struct Shared { v: u32 }
+        }
+        constructors {
+          Default();
+        }
+      }
+    `;
+    const program = new SailsProgram(parser.parse(text));
+    const t: Type | undefined = program.programTypes.get('Shared');
+    const s: ITypeStruct | undefined = t?.kind === 'struct' ? (t as ITypeStruct) : undefined;
+
+    expect(s?.fields).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #1320.

## Summary

**API additions (sails-js v2)**

- Adds `SailsProgram.programTypes: ReadonlyMap<string, Type>` for program-level user types declared in the IDL's `program {…}` block.
- Adds `SailsService.types: ReadonlyMap<string, Type>` for the service's own `types {…}` block (declared-only — does not include types inherited via `extends`).
- Re-exports the v2 IDL AST typings (`Type`, `TypeDecl`, `ITypeStruct`, `ITypeEnum`, `ITypeAlias`, `IIdlDoc`, `IServiceUnit`, …) from the top-level `sails-js` entry, so consumers can `import type { Type } from 'sails-js'` without the `sails-js/types` subpath.

Both maps are eager-built in the constructor and return an empty Map when the corresponding IDL block is absent. They are typed `ReadonlyMap` to block `.set()` at the type level; runtime mutation is not enforced.

For the merged extends-chain scope, consumers continue to use `program.resolveInService(name, decl)` or walk `service.extends[base].types`. The new `service.types` accessor intentionally does not surface inherited types — making each service's declared surface explicit and keeping the existing resolution semantics untouched.

**Why**

vara-wallet and other downstream consumers were reaching into `SailsProgram._doc` via `as any` to enumerate user types (see #1320 for the full writeup). That escape hatch breaks silently the moment a private field is renamed between betas, and consumers couldn't stay type-safe at the AST level because `sails-js-types` was only reachable through the `sails-js/types` subpath.

## Test Coverage

10 new tests in `js/test/idl-v2-types-accessors.test.ts` covering every code path on the new surface:

```
[+] SailsProgram.programTypes
  ├── [★★★ TESTED] populated from program.types
  ├── [★★★ TESTED] empty Map when program block has no types
  ├── [★★★ TESTED] empty Map when no program block (services-only IDL)
  └── [★★★ TESTED] same Map instance on repeated access (eager build)

[+] SailsService.types
  ├── [★★★ TESTED] populated from service.types
  ├── [★★★ TESTED] empty Map when service has no types block
  ├── [★★★ TESTED] declared-only: types in service A absent from service B.types
  ├── [★★★ TESTED] declared-only: base types not pulled into derived via extends
  │                  + sanity check: child.extends.Base.types includes the base type
  │                  + sanity check: program.resolveInService still merges scope
  └── [★★★ TESTED] same Map instance on repeated access (eager build)

[+] Top-level type re-export
  └── [★★★ TESTED] `import type { Type, ITypeStruct } from 'sails-js'` typechecks

COVERAGE: 10/10 paths tested (100%)
```

Tests: 14 → 15 (+1 new file, 10 new test cases). 84 of 84 v2 tests pass on the merged state (10 new + 74 adjacent regression-coverage suites: `idl-v2-parser-type-resolver`, `idl-v2-type-resolver`, `event-type-shape`, `route-idx-header-validation`, `partial-idl`).

## Pre-Landing Review

Five review passes ran before landing. All findings resolved.

| Pass | Findings | Resolution |
|---|---|---|
| `/plan-eng-review` | 4 design tradeoffs (F1 empty-program contract, F2 lazy-vs-eager, F3 test placement, F4 mutation contract honesty) | All 4 resolved as documented in the plan file. |
| `/review` (gstack pre-landing) | 1 INFORMATIONAL (`sails-js-types` resolution) | Tracked in #1344 at the time, then fully closed for this PR by Codex's later finding. |
| `/code-review-graph review-pr` | Graph reported "high risk" (488-node blast radius) | False signal — graph counts transitive dependents, not behavioral delta. Real delta is additive (zero existing surface modified). |
| `/simplify` (3 parallel reviewers) | 1 actionable: `ISailsService` interface missing `types` member | Fixed in `d47b2e95`. |
| `/codex review` | 1 P1: `export type * from 'sails-js-types'` ships unresolvable external module ref | Fixed in `c4696f41` by re-exporting from the bundled `./types.js` instead. Issue #1344 updated to reflect 1/4 of the historical leaks closed; 3 pre-existing references remain in `lib/sails-idl-v2.d.ts`, `lib/util.d.ts`, `lib/parser.d.ts` and will be addressed by the build-side fix tracked in #1344. |

Bot comment from `gemini-code-assist[bot]` (eager-vs-lazy Map build) replied with the F2 rationale; no code change needed (review thread r3201667845).

## Plan Completion

| Item from plan | Status |
|---|---|
| Add `SailsProgram.programTypes` getter | DONE — `js/src/sails-idl-v2.ts:259` |
| Add `SailsService.types` getter | DONE — `js/src/sails-idl-v2.ts:502` |
| Add `types` to `ISailsService` interface | DONE — `js/src/sails-idl-v2.ts:25` |
| Top-level `export type *` from sails-js | DONE — `js/src/index.ts:12` (via `./types.js`) |
| New test file: `idl-v2-types-accessors.test.ts` | DONE — 10 tests |
| CHANGELOG `## Unreleased` entries | DONE — 2 bullets added |
| JSDoc with declared-only contract on `service.types` | DONE |
| JSDoc with empty-Map contract on `programTypes` | DONE |

COMPLETION: 8/8 DONE. No PARTIAL, no NOT DONE.

## Documentation

`js/CHANGELOG.md` updated under `## Unreleased` with two bullets covering the new accessors and the top-level type re-export (including the resolution path via bundled `./types.js`). No README sync needed — the existing README documents only the `sails-js/types` subpath and that path still works exactly as before; the top-level alias is purely additive.

No version bump: `js/package.json` stays at `0.5.1` since this is part of the next unreleased.

## Test plan
- [x] `pnpm test test/idl-v2-types-accessors.test.ts` — 10/10 pass
- [x] `pnpm test` for adjacent v2 suites — 74/74 pass (no regressions)
- [x] `pnpm build` — clean; `lib/index.d.ts` emits `export type * from './types.js'`; `lib/types.d.ts` is fully `dts`-bundled (241 lines, all 49 AST types inlined, zero external module references)
- [x] Type-level smoke check: `import type { Type, ITypeStruct } from 'sails-js'` typechecks at consumer install time without `sails-js-types` in node_modules
- [x] CI: lint + test green on every commit
- [x] Codex P1 (`sails-js-types` external ref in `lib/index.d.ts`) — fixed in this PR
- [ ] Pre-existing unrelated leaks in `lib/sails-idl-v2.d.ts`, `lib/util.d.ts`, `lib/parser.d.ts` — out of scope for this PR, tracked in #1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)