### PR TITLE
feat(macros): allow empty init payload for `#[program]` without constructors, filter program-level dispatch by export codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,9 @@ When this feature is active:
   - `#[export(scale, ethabi)]` — expose through both paths (same as bare `#[export]`).
   - `#[export(payable)]` or `#[export(ethabi, payable)]` — mark the method as payable. `payable` requires `ethabi` transport; writing `#[export(scale, payable)]` is a compile error.
 
-  Transport flags control **runtime dispatch visibility only**. All exported methods remain in the service's IDL metadata, interface hash, and method metadata regardless of their transport selection. Single-transport methods receive a `@codec: scale` or `@codec: ethabi` annotation in the generated IDL.
+  Transport flags control **runtime dispatch visibility only**. For program constructors, the flags decide which init dispatch path can call the constructor. For exposed service constructors (methods within a `#[program]` block that return a service), the flags decide which transport can enter that service route; methods inside the returned service are still filtered by their own `#[export]` transport flags.
+
+  All exported methods remain in the service's IDL metadata, interface hash, and method metadata regardless of their transport selection. Single-transport service methods and program constructors receive a `@codec: scale` or `@codec: ethabi` annotation in the generated IDL.
 
   Without the `ethexe` feature, only `#[export]` and `#[export(scale)]` are accepted; the `ethabi` and `payable` flags are unavailable.
 

--- a/rs/ethexe/macros-tests/tests/program_insta.rs
+++ b/rs/ethexe/macros-tests/tests/program_insta.rs
@@ -166,3 +166,35 @@ fn generates_handle_for_services_with_unwrap_result() {
 
     insta::assert_snapshot!(result);
 }
+
+#[test]
+fn filters_program_level_dispatch_by_transport() {
+    let input = quote! {
+        impl MyProgram {
+            #[export(scale)]
+            pub fn scale_ctor() -> Self {
+                Self
+            }
+
+            #[export(ethabi)]
+            pub fn ethabi_ctor() -> Self {
+                Self
+            }
+
+            #[export(ethabi)]
+            pub fn ethabi_service(&self) -> EthabiService {
+                EthabiService
+            }
+
+            #[export(scale)]
+            pub fn scale_service(&self) -> ScaleService {
+                ScaleService
+            }
+        }
+    };
+
+    let result = gprogram(TokenStream::new(), input).to_string();
+    let result = prettyplease::unparse(&syn::parse_str(&result).unwrap());
+
+    insta::assert_snapshot!(result);
+}

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__filters_program_level_dispatch_by_transport.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__filters_program_level_dispatch_by_transport.snap
@@ -88,11 +88,13 @@ impl sails_rs::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rs::meta::InterfaceId,
     u16,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__filters_program_level_dispatch_by_transport.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__filters_program_level_dispatch_by_transport.snap
@@ -1,6 +1,5 @@
 ---
 source: macros-tests/tests/program_insta.rs
-assertion_line: 199
 expression: result
 ---
 impl MyProgram {
@@ -112,22 +111,23 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
@@ -196,41 +196,28 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-                if route_idx == 1u8 {
-                    let mut service = program_ref.ethabi_service();
-                    let Some(is_async) = <EthabiService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
-                        interface_id,
-                        entry_id,
-                    ) else {
-                        gstd::unknown_input_panic("Unknown service method", &input);
-                    };
-                    if is_async {
-                        gstd::message_loop(async move {
-                            let (output, value, encode_reply) = service
-                                .try_handle_solidity_async(
-                                    interface_id,
-                                    entry_id,
-                                    &input[4..],
-                                )
-                                .await
-                                .unwrap_or_else(|| {
-                                    gstd::unknown_input_panic("Unknown request", &input)
-                                });
-                            let output = if encode_reply {
-                                let selector = __CALLBACK_SIGS[idx];
-                                [selector.as_slice(), output.as_slice()].concat()
-                            } else {
-                                output
-                            };
-                            gstd::msg::reply_bytes(output, value)
-                                .expect("Failed to send output");
-                        });
-                    } else {
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
+            if route_idx == 1u8 {
+                let mut service = program_ref.ethabi_service();
+                let Some(is_async) = <EthabiService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
+                    interface_id,
+                    entry_id,
+                ) else {
+                    gstd::unknown_input_panic("Unknown service method", &input);
+                };
+                if is_async {
+                    gstd::message_loop(async move {
                         let (output, value, encode_reply) = service
-                            .try_handle_solidity(interface_id, entry_id, &input[4..])
+                            .try_handle_solidity_async(
+                                interface_id,
+                                entry_id,
+                                &input[4..],
+                            )
+                            .await
                             .unwrap_or_else(|| {
                                 gstd::unknown_input_panic("Unknown request", &input)
                             });
@@ -242,9 +229,23 @@ pub mod wasm {
                         };
                         gstd::msg::reply_bytes(output, value)
                             .expect("Failed to send output");
-                    }
-                    return;
+                    });
+                } else {
+                    let (output, value, encode_reply) = service
+                        .try_handle_solidity(interface_id, entry_id, &input[4..])
+                        .unwrap_or_else(|| {
+                            gstd::unknown_input_panic("Unknown request", &input)
+                        });
+                    let output = if encode_reply {
+                        let selector = __CALLBACK_SIGS[idx];
+                        [selector.as_slice(), output.as_slice()].concat()
+                    } else {
+                        output
+                    };
+                    gstd::msg::reply_bytes(output, value)
+                        .expect("Failed to send output");
                 }
+                return;
             }
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__filters_program_level_dispatch_by_transport.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__filters_program_level_dispatch_by_transport.snap
@@ -1,0 +1,277 @@
+---
+source: macros-tests/tests/program_insta.rs
+assertion_line: 199
+expression: result
+---
+impl MyProgram {
+    #[export(scale)]
+    pub fn scale_ctor() -> Self {
+        Self
+    }
+    #[export(ethabi)]
+    pub fn ethabi_ctor() -> Self {
+        Self
+    }
+    fn __ethabi_service(&self) -> EthabiService {
+        EthabiService
+    }
+    fn __scale_service(&self) -> ScaleService {
+        ScaleService
+    }
+    pub fn ethabi_service(
+        &self,
+    ) -> <EthabiService as sails_rs::gstd::services::Service>::Exposure {
+        let service = self.__ethabi_service();
+        let exposure = <EthabiService as sails_rs::gstd::services::Service>::expose(
+            service,
+            1u8,
+        );
+        exposure
+    }
+    pub fn scale_service(
+        &self,
+    ) -> <ScaleService as sails_rs::gstd::services::Service>::Exposure {
+        let service = self.__scale_service();
+        let exposure = <ScaleService as sails_rs::gstd::services::Service>::expose(
+            service,
+            2u8,
+        );
+        exposure
+    }
+}
+impl sails_rs::meta::ProgramMeta for MyProgram {
+    type ConstructorsMeta = meta_in_program::ConstructorsMeta;
+    const SERVICES: &'static [(&'static str, sails_rs::meta::AnyServiceMeta)] = &[
+        ("EthabiService", <EthabiService as sails_rs::meta::ServiceMeta>::META),
+        ("ScaleService", <ScaleService as sails_rs::meta::ServiceMeta>::META),
+    ];
+    const ASYNC: bool = <EthabiService as sails_rs::meta::ServiceMeta>::ASYNC
+        || <ScaleService as sails_rs::meta::ServiceMeta>::ASYNC;
+}
+mod meta_in_program {
+    use super::*;
+    sails_rs::invocation_io!(
+        pub struct __EthabiCtorParams {}, entry_id = 0u16, decode = false,
+    );
+    sails_rs::invocation_io!(pub struct __ScaleCtorParams {}, entry_id = 1u16,);
+    #[derive(sails_rs::TypeInfo)]
+    #[type_info(crate = sails_rs::type_info)]
+    pub enum ConstructorsMeta {
+        #[annotate(codec = "ethabi")]
+        EthabiCtor(__EthabiCtorParams),
+        #[annotate(codec = "scale")]
+        ScaleCtor(__ScaleCtorParams),
+    }
+}
+impl sails_rs::solidity::ProgramSignature for MyProgram {
+    const CTORS: &'static [sails_rs::solidity::MethodExpo] = &[
+        (
+            sails_rs::meta::InterfaceId::zero(),
+            0u16,
+            "ethabiCtor",
+            <<(
+                bool,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+            <<(
+                sails_rs::alloy_primitives::B256,
+            ) as sails_rs::alloy_sol_types::SolValue>::SolType as sails_rs::alloy_sol_types::SolType>::SOL_NAME,
+        ),
+    ];
+    const SERVICES: &'static [sails_rs::solidity::ServiceExpo] = &[
+        (
+            "ethabiService",
+            1u8,
+            <EthabiService as sails_rs::solidity::ServiceSignature>::METHODS,
+        ),
+    ];
+    const METHODS_LEN: usize = <EthabiService as sails_rs::solidity::ServiceSignature>::METHODS
+        .len();
+}
+const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
+    .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
+    .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
+const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
+    MyProgram,
+>::method_sigs();
+const __METHOD_ROUTES: [(
+    sails_rs::meta::InterfaceId,
+    u16,
+    u8,
+); <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
+    MyProgram,
+>::method_routes();
+const __CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
+    MyProgram,
+>::callback_sigs();
+#[cfg(target_arch = "wasm32")]
+pub mod wasm {
+    use super::*;
+    use sails_rs::{gstd, hex, prelude::*};
+    static mut PROGRAM: Option<MyProgram> = None;
+    #[unsafe(no_mangle)]
+    extern "C" fn init() {
+        let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
+            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
+                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
+                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
+                    if encode_reply {
+                        let output = [
+                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                            gstd::msg::id().into_bytes().as_slice(),
+                        ]
+                            .concat();
+                        gstd::msg::reply_bytes(output, 0)
+                            .expect("Failed to send output");
+                    }
+                    return;
+                }
+            }
+        }
+        if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
+            &mut input,
+        ) {
+            if header.interface_id() != sails_rs::meta::InterfaceId::zero() {
+                sails_rs::gstd::unknown_input_panic(
+                    "Non zero ctor interface_id",
+                    header.to_bytes().as_slice(),
+                );
+            }
+            match header.entry_id() {
+                1u16 => {
+                    let (): () = sails_rs::Decode::decode(&mut input)
+                        .unwrap_or_else(|_| sails_rs::gstd::unknown_input_panic(
+                            "Unknown request",
+                            input,
+                        ));
+                    #[cfg(target_arch = "wasm32")]
+                    if sails_rs::gstd::msg::value() > 0 {
+                        core::panic!("'scale_ctor' accepts no value");
+                    }
+                    sails_rs::program_ctor!(
+                        PROGRAM = MyProgram::scale_ctor(), params_struct =
+                        meta_in_program::__ScaleCtorParams
+                    )
+                }
+                _ => {
+                    sails_rs::gstd::unknown_input_panic(
+                        "Unexpected ctor entry_id",
+                        input,
+                    )
+                }
+            }
+        }
+    }
+    fn match_ctor_solidity(entry_id: u16, input: &[u8]) -> Option<bool> {
+        match entry_id {
+            0u16 => {
+                let (__encode_reply,): (bool,) = sails_rs::alloy_sol_types::SolValue::abi_decode_params(
+                        input,
+                    )
+                    .expect("Failed to decode request");
+                #[cfg(target_arch = "wasm32")]
+                if sails_rs::gstd::msg::value() > 0 {
+                    core::panic!("'ethabi_ctor' accepts no value");
+                }
+                let program = MyProgram::ethabi_ctor();
+                unsafe { PROGRAM = Some(program) };
+                Some(__encode_reply)
+            }
+            _ => None,
+        }
+    }
+    const SERVICES_COUNT: usize = 2usize
+        + sails_rs::meta::count_base_services::<EthabiService>()
+        + sails_rs::meta::count_base_services::<ScaleService>();
+    const INTERFACE_IDS: &'static [(sails_rs::meta::InterfaceId, u8)] = &sails_rs::meta::interface_ids::<
+        SERVICES_COUNT,
+    >(
+        &[
+            sails_rs::meta::BaseServiceMeta::new::<EthabiService>(""),
+            sails_rs::meta::BaseServiceMeta::new::<ScaleService>(""),
+        ],
+    );
+    #[unsafe(no_mangle)]
+    extern "C" fn handle() {
+        let mut input = gstd::msg::load_bytes().expect("Failed to read input");
+        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
+            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
+                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
+                if route_idx == 1u8 {
+                    let mut service = program_ref.ethabi_service();
+                    let Some(is_async) = <EthabiService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
+                        interface_id,
+                        entry_id,
+                    ) else {
+                        gstd::unknown_input_panic("Unknown service method", &input);
+                    };
+                    if is_async {
+                        gstd::message_loop(async move {
+                            let (output, value, encode_reply) = service
+                                .try_handle_solidity_async(
+                                    interface_id,
+                                    entry_id,
+                                    &input[4..],
+                                )
+                                .await
+                                .unwrap_or_else(|| {
+                                    gstd::unknown_input_panic("Unknown request", &input)
+                                });
+                            let output = if encode_reply {
+                                let selector = __CALLBACK_SIGS[idx];
+                                [selector.as_slice(), output.as_slice()].concat()
+                            } else {
+                                output
+                            };
+                            gstd::msg::reply_bytes(output, value)
+                                .expect("Failed to send output");
+                        });
+                    } else {
+                        let (output, value, encode_reply) = service
+                            .try_handle_solidity(interface_id, entry_id, &input[4..])
+                            .unwrap_or_else(|| {
+                                gstd::unknown_input_panic("Unknown request", &input)
+                            });
+                        let output = if encode_reply {
+                            let selector = __CALLBACK_SIGS[idx];
+                            [selector.as_slice(), output.as_slice()].concat()
+                        } else {
+                            output
+                        };
+                        gstd::msg::reply_bytes(output, value)
+                            .expect("Failed to send output");
+                    }
+                    return;
+                }
+            }
+        }
+        if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
+            &mut input.as_slice(),
+        ) {
+            let header_len = header.hlen().inner() as usize;
+            let (interface_id, route_id, entry_id) = header
+                .try_match_interfaces(INTERFACE_IDS)
+                .expect("Failed to find matching service")
+                .into_inner();
+            match route_id {
+                2u8 => {
+                    let svc = program_ref.scale_service();
+                    sails_rs::service_route_dispatch!(
+                        svc : ScaleService, interface_id = interface_id, entry_id =
+                        entry_id, input = & input[header_len..],
+                    );
+                }
+                _ => gstd::unknown_input_panic("Unknown route_id", &[route_id]),
+            }
+        }
+    }
+    #[unsafe(no_mangle)]
+    extern "C" fn handle_reply() {
+        use sails_rs::meta::ProgramMeta;
+        if MyProgram::ASYNC {
+            gstd::handle_reply_with_hook();
+        }
+    }
+}

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
@@ -95,22 +95,23 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
@@ -214,10 +215,11 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-            }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
@@ -72,11 +72,13 @@ impl sails_rs::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rs::meta::InterfaceId,
     u16,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -104,22 +104,23 @@ pub mod wasm {
             );
             return;
         }
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
@@ -188,41 +189,28 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-                if route_idx == 1u8 {
-                    let mut service = program_ref.service1();
-                    let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
-                        interface_id,
-                        entry_id,
-                    ) else {
-                        gstd::unknown_input_panic("Unknown service method", &input);
-                    };
-                    if is_async {
-                        gstd::message_loop(async move {
-                            let (output, value, encode_reply) = service
-                                .try_handle_solidity_async(
-                                    interface_id,
-                                    entry_id,
-                                    &input[4..],
-                                )
-                                .await
-                                .unwrap_or_else(|| {
-                                    gstd::unknown_input_panic("Unknown request", &input)
-                                });
-                            let output = if encode_reply {
-                                let selector = __CALLBACK_SIGS[idx];
-                                [selector.as_slice(), output.as_slice()].concat()
-                            } else {
-                                output
-                            };
-                            gstd::msg::reply_bytes(output, value)
-                                .expect("Failed to send output");
-                        });
-                    } else {
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
+            if route_idx == 1u8 {
+                let mut service = program_ref.service1();
+                let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
+                    interface_id,
+                    entry_id,
+                ) else {
+                    gstd::unknown_input_panic("Unknown service method", &input);
+                };
+                if is_async {
+                    gstd::message_loop(async move {
                         let (output, value, encode_reply) = service
-                            .try_handle_solidity(interface_id, entry_id, &input[4..])
+                            .try_handle_solidity_async(
+                                interface_id,
+                                entry_id,
+                                &input[4..],
+                            )
+                            .await
                             .unwrap_or_else(|| {
                                 gstd::unknown_input_panic("Unknown request", &input)
                             });
@@ -234,41 +222,41 @@ pub mod wasm {
                         };
                         gstd::msg::reply_bytes(output, value)
                             .expect("Failed to send output");
-                    }
-                    return;
-                }
-                if route_idx == 2u8 {
-                    let mut service = program_ref.service2();
-                    let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
-                        interface_id,
-                        entry_id,
-                    ) else {
-                        gstd::unknown_input_panic("Unknown service method", &input);
-                    };
-                    if is_async {
-                        gstd::message_loop(async move {
-                            let (output, value, encode_reply) = service
-                                .try_handle_solidity_async(
-                                    interface_id,
-                                    entry_id,
-                                    &input[4..],
-                                )
-                                .await
-                                .unwrap_or_else(|| {
-                                    gstd::unknown_input_panic("Unknown request", &input)
-                                });
-                            let output = if encode_reply {
-                                let selector = __CALLBACK_SIGS[idx];
-                                [selector.as_slice(), output.as_slice()].concat()
-                            } else {
-                                output
-                            };
-                            gstd::msg::reply_bytes(output, value)
-                                .expect("Failed to send output");
+                    });
+                } else {
+                    let (output, value, encode_reply) = service
+                        .try_handle_solidity(interface_id, entry_id, &input[4..])
+                        .unwrap_or_else(|| {
+                            gstd::unknown_input_panic("Unknown request", &input)
                         });
+                    let output = if encode_reply {
+                        let selector = __CALLBACK_SIGS[idx];
+                        [selector.as_slice(), output.as_slice()].concat()
                     } else {
+                        output
+                    };
+                    gstd::msg::reply_bytes(output, value)
+                        .expect("Failed to send output");
+                }
+                return;
+            }
+            if route_idx == 2u8 {
+                let mut service = program_ref.service2();
+                let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
+                    interface_id,
+                    entry_id,
+                ) else {
+                    gstd::unknown_input_panic("Unknown service method", &input);
+                };
+                if is_async {
+                    gstd::message_loop(async move {
                         let (output, value, encode_reply) = service
-                            .try_handle_solidity(interface_id, entry_id, &input[4..])
+                            .try_handle_solidity_async(
+                                interface_id,
+                                entry_id,
+                                &input[4..],
+                            )
+                            .await
                             .unwrap_or_else(|| {
                                 gstd::unknown_input_panic("Unknown request", &input)
                             });
@@ -280,9 +268,23 @@ pub mod wasm {
                         };
                         gstd::msg::reply_bytes(output, value)
                             .expect("Failed to send output");
-                    }
-                    return;
+                    });
+                } else {
+                    let (output, value, encode_reply) = service
+                        .try_handle_solidity(interface_id, entry_id, &input[4..])
+                        .unwrap_or_else(|| {
+                            gstd::unknown_input_panic("Unknown request", &input)
+                        });
+                    let output = if encode_reply {
+                        let selector = __CALLBACK_SIGS[idx];
+                        [selector.as_slice(), output.as_slice()].concat()
+                    } else {
+                        output
+                    };
+                    gstd::msg::reply_bytes(output, value)
+                        .expect("Failed to send output");
                 }
+                return;
             }
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -74,11 +74,13 @@ impl sails_rs::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rs::meta::InterfaceId,
     u16,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -97,6 +97,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
                 let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
@@ -1,6 +1,5 @@
 ---
 source: macros-tests/tests/program_insta.rs
-assertion_line: 167
 expression: result
 ---
 impl MyProgram {
@@ -75,11 +74,13 @@ impl sails_rs::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rs::meta::InterfaceId,
     u16,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
@@ -97,6 +97,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
                 let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
@@ -1,5 +1,6 @@
 ---
 source: macros-tests/tests/program_insta.rs
+assertion_line: 167
 expression: result
 ---
 impl MyProgram {
@@ -104,22 +105,23 @@ pub mod wasm {
             );
             return;
         }
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
@@ -188,41 +190,28 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-                if route_idx == 1u8 {
-                    let mut service = program_ref.service1();
-                    let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
-                        interface_id,
-                        entry_id,
-                    ) else {
-                        gstd::unknown_input_panic("Unknown service method", &input);
-                    };
-                    if is_async {
-                        gstd::message_loop(async move {
-                            let (output, value, encode_reply) = service
-                                .try_handle_solidity_async(
-                                    interface_id,
-                                    entry_id,
-                                    &input[4..],
-                                )
-                                .await
-                                .unwrap_or_else(|| {
-                                    gstd::unknown_input_panic("Unknown request", &input)
-                                });
-                            let output = if encode_reply {
-                                let selector = __CALLBACK_SIGS[idx];
-                                [selector.as_slice(), output.as_slice()].concat()
-                            } else {
-                                output
-                            };
-                            gstd::msg::reply_bytes(output, value)
-                                .expect("Failed to send output");
-                        });
-                    } else {
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
+            if route_idx == 1u8 {
+                let mut service = program_ref.service1();
+                let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
+                    interface_id,
+                    entry_id,
+                ) else {
+                    gstd::unknown_input_panic("Unknown service method", &input);
+                };
+                if is_async {
+                    gstd::message_loop(async move {
                         let (output, value, encode_reply) = service
-                            .try_handle_solidity(interface_id, entry_id, &input[4..])
+                            .try_handle_solidity_async(
+                                interface_id,
+                                entry_id,
+                                &input[4..],
+                            )
+                            .await
                             .unwrap_or_else(|| {
                                 gstd::unknown_input_panic("Unknown request", &input)
                             });
@@ -234,41 +223,41 @@ pub mod wasm {
                         };
                         gstd::msg::reply_bytes(output, value)
                             .expect("Failed to send output");
-                    }
-                    return;
-                }
-                if route_idx == 2u8 {
-                    let mut service = program_ref.service2();
-                    let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
-                        interface_id,
-                        entry_id,
-                    ) else {
-                        gstd::unknown_input_panic("Unknown service method", &input);
-                    };
-                    if is_async {
-                        gstd::message_loop(async move {
-                            let (output, value, encode_reply) = service
-                                .try_handle_solidity_async(
-                                    interface_id,
-                                    entry_id,
-                                    &input[4..],
-                                )
-                                .await
-                                .unwrap_or_else(|| {
-                                    gstd::unknown_input_panic("Unknown request", &input)
-                                });
-                            let output = if encode_reply {
-                                let selector = __CALLBACK_SIGS[idx];
-                                [selector.as_slice(), output.as_slice()].concat()
-                            } else {
-                                output
-                            };
-                            gstd::msg::reply_bytes(output, value)
-                                .expect("Failed to send output");
+                    });
+                } else {
+                    let (output, value, encode_reply) = service
+                        .try_handle_solidity(interface_id, entry_id, &input[4..])
+                        .unwrap_or_else(|| {
+                            gstd::unknown_input_panic("Unknown request", &input)
                         });
+                    let output = if encode_reply {
+                        let selector = __CALLBACK_SIGS[idx];
+                        [selector.as_slice(), output.as_slice()].concat()
                     } else {
+                        output
+                    };
+                    gstd::msg::reply_bytes(output, value)
+                        .expect("Failed to send output");
+                }
+                return;
+            }
+            if route_idx == 2u8 {
+                let mut service = program_ref.service2();
+                let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
+                    interface_id,
+                    entry_id,
+                ) else {
+                    gstd::unknown_input_panic("Unknown service method", &input);
+                };
+                if is_async {
+                    gstd::message_loop(async move {
                         let (output, value, encode_reply) = service
-                            .try_handle_solidity(interface_id, entry_id, &input[4..])
+                            .try_handle_solidity_async(
+                                interface_id,
+                                entry_id,
+                                &input[4..],
+                            )
+                            .await
                             .unwrap_or_else(|| {
                                 gstd::unknown_input_panic("Unknown request", &input)
                             });
@@ -280,9 +269,23 @@ pub mod wasm {
                         };
                         gstd::msg::reply_bytes(output, value)
                             .expect("Failed to send output");
-                    }
-                    return;
+                    });
+                } else {
+                    let (output, value, encode_reply) = service
+                        .try_handle_solidity(interface_id, entry_id, &input[4..])
+                        .unwrap_or_else(|| {
+                            gstd::unknown_input_panic("Unknown request", &input)
+                        });
+                    let output = if encode_reply {
+                        let selector = __CALLBACK_SIGS[idx];
+                        [selector.as_slice(), output.as_slice()].concat()
+                    } else {
+                        output
+                    };
+                    gstd::msg::reply_bytes(output, value)
+                        .expect("Failed to send output");
                 }
+                return;
             }
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
@@ -1,5 +1,6 @@
 ---
 source: macros-tests/tests/program_insta.rs
+assertion_line: 67
 expression: result
 ---
 impl MyProgram {
@@ -86,22 +87,23 @@ pub mod wasm {
             );
             return;
         }
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
@@ -164,41 +166,28 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-                if route_idx == 1u8 {
-                    let mut service = program_ref.service();
-                    let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
-                        interface_id,
-                        entry_id,
-                    ) else {
-                        gstd::unknown_input_panic("Unknown service method", &input);
-                    };
-                    if is_async {
-                        gstd::message_loop(async move {
-                            let (output, value, encode_reply) = service
-                                .try_handle_solidity_async(
-                                    interface_id,
-                                    entry_id,
-                                    &input[4..],
-                                )
-                                .await
-                                .unwrap_or_else(|| {
-                                    gstd::unknown_input_panic("Unknown request", &input)
-                                });
-                            let output = if encode_reply {
-                                let selector = __CALLBACK_SIGS[idx];
-                                [selector.as_slice(), output.as_slice()].concat()
-                            } else {
-                                output
-                            };
-                            gstd::msg::reply_bytes(output, value)
-                                .expect("Failed to send output");
-                        });
-                    } else {
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
+            if route_idx == 1u8 {
+                let mut service = program_ref.service();
+                let Some(is_async) = <MyService as sails_rs::gstd::services::Service>::Exposure::check_asyncness(
+                    interface_id,
+                    entry_id,
+                ) else {
+                    gstd::unknown_input_panic("Unknown service method", &input);
+                };
+                if is_async {
+                    gstd::message_loop(async move {
                         let (output, value, encode_reply) = service
-                            .try_handle_solidity(interface_id, entry_id, &input[4..])
+                            .try_handle_solidity_async(
+                                interface_id,
+                                entry_id,
+                                &input[4..],
+                            )
+                            .await
                             .unwrap_or_else(|| {
                                 gstd::unknown_input_panic("Unknown request", &input)
                             });
@@ -210,9 +199,23 @@ pub mod wasm {
                         };
                         gstd::msg::reply_bytes(output, value)
                             .expect("Failed to send output");
-                    }
-                    return;
+                    });
+                } else {
+                    let (output, value, encode_reply) = service
+                        .try_handle_solidity(interface_id, entry_id, &input[4..])
+                        .unwrap_or_else(|| {
+                            gstd::unknown_input_panic("Unknown request", &input)
+                        });
+                    let output = if encode_reply {
+                        let selector = __CALLBACK_SIGS[idx];
+                        [selector.as_slice(), output.as_slice()].concat()
+                    } else {
+                        output
+                    };
+                    gstd::msg::reply_bytes(output, value)
+                        .expect("Failed to send output");
                 }
+                return;
             }
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
@@ -1,6 +1,5 @@
 ---
 source: macros-tests/tests/program_insta.rs
-assertion_line: 67
 expression: result
 ---
 impl MyProgram {
@@ -57,11 +56,13 @@ impl sails_rs::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rs::meta::InterfaceId,
     u16,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
@@ -79,6 +79,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
                 let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
@@ -65,6 +65,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rename::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
                 let (_, entry_id, ..) = <MyProgram as sails_rename::solidity::ProgramSignature>::CTORS[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
@@ -1,5 +1,6 @@
 ---
 source: macros-tests/tests/program_insta.rs
+assertion_line: 101
 expression: result
 ---
 impl MyProgram {
@@ -72,22 +73,23 @@ pub mod wasm {
             );
             return;
         }
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rename::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rename::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rename::meta::SailsMessageHeader as sails_rename::Decode>::decode(
             &mut input,
@@ -149,10 +151,11 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-            }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
         }
         if let Ok(header) = <sails_rename::meta::SailsMessageHeader as sails_rename::Decode>::decode(
             &mut input.as_slice(),

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
@@ -1,6 +1,5 @@
 ---
 source: macros-tests/tests/program_insta.rs
-assertion_line: 101
 expression: result
 ---
 impl MyProgram {
@@ -41,6 +40,7 @@ impl sails_rename::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rename::solidity::ProgramSignature>::CTORS
     .len()] = sails_rename::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rename::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rename::solidity::ProgramSignature>::CTORS
     .len()] = sails_rename::solidity::ConstProgramMeta::<
     MyProgram,
@@ -48,6 +48,7 @@ const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rename::solidity::Prog
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rename::solidity::ProgramSignature>::METHODS_LEN] = sails_rename::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rename::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rename::meta::InterfaceId,
     u16,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
@@ -1,5 +1,6 @@
 ---
 source: macros-tests/tests/program_insta.rs
+assertion_line: 38
 expression: result
 ---
 impl MyProgram {
@@ -89,22 +90,23 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
@@ -208,10 +210,11 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-            }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
@@ -1,6 +1,5 @@
 ---
 source: macros-tests/tests/program_insta.rs
-assertion_line: 38
 expression: result
 ---
 impl MyProgram {
@@ -67,11 +66,13 @@ impl sails_rs::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rs::meta::InterfaceId,
     u16,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
@@ -63,6 +63,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
                 let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
@@ -1,6 +1,5 @@
 ---
 source: macros-tests/tests/program_insta.rs
-assertion_line: 51
 expression: result
 ---
 impl MyProgram {
@@ -41,11 +40,13 @@ impl sails_rs::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rs::meta::InterfaceId,
     u16,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
@@ -1,5 +1,6 @@
 ---
 source: macros-tests/tests/program_insta.rs
+assertion_line: 51
 expression: result
 ---
 impl MyProgram {
@@ -70,22 +71,23 @@ pub mod wasm {
             );
             return;
         }
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
@@ -147,10 +149,11 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-            }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
@@ -1,6 +1,5 @@
 ---
 source: macros-tests/tests/program_insta.rs
-assertion_line: 18
 expression: result
 ---
 impl MyProgram {
@@ -46,11 +45,13 @@ impl sails_rs::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rs::meta::InterfaceId,
     u16,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
@@ -1,5 +1,6 @@
 ---
 source: macros-tests/tests/program_insta.rs
+assertion_line: 18
 expression: result
 ---
 impl MyProgram {
@@ -68,22 +69,23 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
@@ -153,10 +155,11 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-            }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
@@ -1,5 +1,6 @@
 ---
 source: macros-tests/tests/program_insta.rs
+assertion_line: 146
 expression: result
 ---
 impl MyProgram {
@@ -91,22 +92,23 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                let (_, entry_id, ..) = <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx];
-                if let Some(encode_reply) = match_ctor_solidity(entry_id, &input[4..]) {
-                    if encode_reply {
-                        let output = [
-                            __CTOR_CALLBACK_SIGS[idx].as_slice(),
-                            gstd::msg::id().into_bytes().as_slice(),
-                        ]
-                            .concat();
-                        gstd::msg::reply_bytes(output, 0)
-                            .expect("Failed to send output");
-                    }
-                    return;
-                }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+            && let Some(encode_reply) = match_ctor_solidity(
+                <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS[idx].1,
+                &input[4..],
+            )
+        {
+            if encode_reply {
+                let output = [
+                    __CTOR_CALLBACK_SIGS[idx].as_slice(),
+                    gstd::msg::id().into_bytes().as_slice(),
+                ]
+                    .concat();
+                gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
             }
+            return;
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
@@ -210,10 +212,11 @@ pub mod wasm {
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
         let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
-        if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-            if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-            }
+        if let Some(input_sig) = input.get(..4)
+            && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+            && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+        {
+            let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
         }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
@@ -1,6 +1,5 @@
 ---
 source: macros-tests/tests/program_insta.rs
-assertion_line: 146
 expression: result
 ---
 impl MyProgram {
@@ -69,11 +68,13 @@ impl sails_rs::solidity::ProgramSignature for MyProgram {
 }
 const __CTOR_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__CTOR_SIGS);
 const __CTOR_CALLBACK_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::CTORS
     .len()] = sails_rs::solidity::ConstProgramMeta::<MyProgram>::ctor_callback_sigs();
 const __METHOD_SIGS: [[u8; 4]; <MyProgram as sails_rs::solidity::ProgramSignature>::METHODS_LEN] = sails_rs::solidity::ConstProgramMeta::<
     MyProgram,
 >::method_sigs();
+const _: () = sails_rs::solidity::assert_unique_selectors(&__METHOD_SIGS);
 const __METHOD_ROUTES: [(
     sails_rs::meta::InterfaceId,
     u16,

--- a/rs/macros/core/src/program/ethexe.rs
+++ b/rs/macros/core/src/program/ethexe.rs
@@ -31,18 +31,24 @@ impl ProgramBuilder {
         let program_ctors = self.program_ctors();
         let program_ctor_sigs = program_ctors
             .iter()
+            .filter(|fn_builder| fn_builder.has_ethabi_codec())
             .map(|fn_builder| fn_builder.sol_handler_signature(None));
 
         let service_ctors = self.service_ctors();
         let service_ctor_sigs = service_ctors
             .iter()
+            .filter(|fn_builder| fn_builder.has_ethabi_codec())
             .map(|fn_builder| fn_builder.sol_service_signature());
 
-        let methods_len_iter = service_ctors.iter().map(|fn_builder| {
+        let ethabi_service_ctors = service_ctors
+            .iter()
+            .filter(|fn_builder| fn_builder.has_ethabi_codec())
+            .collect::<Vec<_>>();
+        let methods_len_iter = ethabi_service_ctors.iter().map(|fn_builder| {
             let service_type = &fn_builder.result_type;
             quote!(<#service_type as #sails_path::solidity::ServiceSignature>::METHODS.len())
         });
-        let methods_len = if service_ctors.is_empty() {
+        let methods_len = if ethabi_service_ctors.is_empty() {
             quote! {0}
         } else {
             quote! {#(#methods_len_iter) + *}
@@ -84,6 +90,7 @@ impl ProgramBuilder {
         let program_ctors = self.program_ctors();
         let ctor_branches = program_ctors
             .iter()
+            .filter(|fn_builder| fn_builder.has_ethabi_codec())
             .map(|fn_builder| fn_builder.sol_ctor_branch_impl(program_type_path, program_ident));
 
         quote! {

--- a/rs/macros/core/src/program/ethexe.rs
+++ b/rs/macros/core/src/program/ethexe.rs
@@ -108,29 +108,32 @@ impl ProgramBuilder {
         let (program_type_path, ..) = self.impl_type();
 
         quote! {
-            if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&#input_ident[..4]) {
-                if let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig) {
-                    let (_, entry_id, ..) = <#program_type_path as #sails_path::solidity::ProgramSignature>::CTORS[idx];
-                    if let Some(encode_reply) = match_ctor_solidity(entry_id, &#input_ident[4..]) {
-                        // add callbak selector if `encode_reply` is set
-                        if encode_reply {
-                            let output = [__CTOR_CALLBACK_SIGS[idx].as_slice(), gstd::msg::id().into_bytes().as_slice()].concat();
-                            gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
-                        }
-                        return;
-                    }
+            if let Some(input_sig) = #input_ident.get(..4)
+                && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+                && let Some(idx) = __CTOR_SIGS.iter().position(|s| s == &sig)
+                && let Some(encode_reply) = match_ctor_solidity(
+                    <#program_type_path as #sails_path::solidity::ProgramSignature>::CTORS[idx].1,
+                    &#input_ident[4..],
+                )
+            {
+                // add callback selector if `encode_reply` is set
+                if encode_reply {
+                    let output = [__CTOR_CALLBACK_SIGS[idx].as_slice(), gstd::msg::id().into_bytes().as_slice()].concat();
+                    gstd::msg::reply_bytes(output, 0).expect("Failed to send output");
                 }
+                return;
             }
         }
     }
 
     pub fn sol_main(&self, solidity_dispatchers: &[TokenStream]) -> TokenStream {
         quote! {
-            if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
-                if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
-                    let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
-                    #(#solidity_dispatchers)*
-                }
+            if let Some(input_sig) = input.get(..4)
+                && let Ok(sig) = <[u8; 4]>::try_from(input_sig)
+                && let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig)
+            {
+                let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];
+                #(#solidity_dispatchers)*
             }
         }
     }
@@ -139,7 +142,7 @@ impl ProgramBuilder {
 impl FnBuilder<'_> {
     fn sol_service_signature(&self) -> TokenStream {
         let sails_path = self.sails_path;
-        let route_idx = (self.entry_id + 1) as u8;
+        let route_idx = self.service_route_idx();
         let service_name = self.route_camel_case();
         let service_type = &self.result_type;
 
@@ -247,7 +250,7 @@ impl FnBuilder<'_> {
 
     pub(crate) fn sol_service_invocation(&self) -> TokenStream2 {
         let sails_path = self.sails_path;
-        let route_idx = (self.entry_id + 1) as u8;
+        let route_idx = self.service_route_idx();
         let service_ctor_ident = self.ident;
         let service_type = &self.result_type;
 
@@ -265,7 +268,7 @@ impl FnBuilder<'_> {
                             .unwrap_or_else(|| {
                                 gstd::unknown_input_panic("Unknown request", &input)
                             });
-                        // add callbak selector if `encode_reply` is set
+                        // add callback selector if `encode_reply` is set
                         let output = if encode_reply {
                             let selector = __CALLBACK_SIGS[idx];
                             [selector.as_slice(), output.as_slice()].concat()
@@ -280,7 +283,7 @@ impl FnBuilder<'_> {
                         .unwrap_or_else(|| {
                             gstd::unknown_input_panic("Unknown request", &input)
                         });
-                    // add callbak selector if `encode_reply` is set
+                    // add callback selector if `encode_reply` is set
                     let output = if encode_reply {
                         let selector = __CALLBACK_SIGS[idx];
                         [selector.as_slice(), output.as_slice()].concat()

--- a/rs/macros/core/src/program/ethexe.rs
+++ b/rs/macros/core/src/program/ethexe.rs
@@ -74,10 +74,12 @@ impl ProgramBuilder {
         quote! {
             const __CTOR_SIGS: [[u8; 4]; <#program_type_path as #sails_path::solidity::ProgramSignature>::CTORS.len()]
                 = #sails_path::solidity::ConstProgramMeta::<#program_type_path>::ctor_sigs();
+            const _: () = #sails_path::solidity::assert_unique_selectors(&__CTOR_SIGS);
             const __CTOR_CALLBACK_SIGS: [[u8; 4]; <#program_type_path as #sails_path::solidity::ProgramSignature>::CTORS.len()]
                 = #sails_path::solidity::ConstProgramMeta::<#program_type_path>::ctor_callback_sigs();
             const __METHOD_SIGS: [[u8; 4]; <#program_type_path as #sails_path::solidity::ProgramSignature>::METHODS_LEN]
                 = #sails_path::solidity::ConstProgramMeta::<#program_type_path>::method_sigs();
+            const _: () = #sails_path::solidity::assert_unique_selectors(&__METHOD_SIGS);
             const __METHOD_ROUTES: [(#sails_path::meta::InterfaceId, u16, u8); <#program_type_path as #sails_path::solidity::ProgramSignature>::METHODS_LEN]
                 = #sails_path::solidity::ConstProgramMeta::<#program_type_path>::method_routes();
             const __CALLBACK_SIGS: [[u8; 4]; <#program_type_path as #sails_path::solidity::ProgramSignature>::METHODS_LEN]

--- a/rs/macros/core/src/program/mod.rs
+++ b/rs/macros/core/src/program/mod.rs
@@ -222,7 +222,7 @@ impl ProgramBuilder {
                 services_ids_data.push(service_type.clone());
                 if fn_builder.has_scale_codec() {
                     route_dispatch_data.push((
-                        (fn_builder.entry_id + 1) as u8,
+                        fn_builder.service_route_idx(),
                         service_ctor_ident,
                         service_type,
                     ));
@@ -675,6 +675,13 @@ fn handle_reply_predicate(fn_item: &ImplItemFn) -> bool {
 }
 
 impl FnBuilder<'_> {
+    fn service_route_idx(&self) -> u8 {
+        if self.entry_id >= u8::MAX as u16 {
+            abort!(self.ident, "too many services; maximum is 255");
+        }
+        (self.entry_id + 1) as u8
+    }
+
     fn service_meta(&self) -> TokenStream2 {
         let sails_path = self.sails_path;
         let route = &self.route;
@@ -705,7 +712,7 @@ impl FnBuilder<'_> {
     fn wrapping_service_ctor_fn(&self, original_service_ctor_fn_ident: &Ident) -> ImplItemFn {
         let sails_path = self.sails_path;
         let service_type = &self.result_type;
-        let route_idx = (self.entry_id + 1) as u8;
+        let route_idx = self.service_route_idx();
         let unwrap_token = self.error_type.is_some().then(|| quote!(.unwrap()));
 
         let mut wrapping_service_ctor_fn = self.impl_fn.clone();

--- a/rs/macros/core/src/program/mod.rs
+++ b/rs/macros/core/src/program/mod.rs
@@ -210,7 +210,9 @@ impl ProgramBuilder {
                 }
 
                 #[cfg(feature = "ethexe")]
-                solidity_dispatchers.push(fn_builder.sol_service_invocation());
+                if fn_builder.has_ethabi_codec() {
+                    solidity_dispatchers.push(fn_builder.sol_service_invocation());
+                }
 
                 // Extract data needed later (not the fn_builder itself)
                 let service_type = fn_builder.result_type.clone();
@@ -218,7 +220,13 @@ impl ProgramBuilder {
 
                 services_count_data.push(service_type.clone());
                 services_ids_data.push(service_type.clone());
-                route_dispatch_data.push((service_ctor_ident, service_type));
+                if fn_builder.has_scale_codec() {
+                    route_dispatch_data.push((
+                        (fn_builder.entry_id + 1) as u8,
+                        service_ctor_ident,
+                        service_type,
+                    ));
+                }
 
                 modifications.push((idx, original_service_ctor_fn, wrapping_service_ctor_fn));
             }
@@ -299,10 +307,7 @@ impl ProgramBuilder {
         // Generate route_id match arms using extracted data
         let route_dispatches = route_dispatch_data
             .iter()
-            .enumerate()
-            .map(|(idx, (service_ctor_ident, service_type))| {
-                let route_idx = (idx + 1) as u8;
-
+            .map(|(route_idx, service_ctor_ident, service_type)| {
                 quote! {
                     #route_idx => {
                         let svc = program_ref.#service_ctor_ident();
@@ -404,11 +409,13 @@ impl ProgramBuilder {
         let mut ctor_meta_variants = Vec::with_capacity(program_ctors.len());
 
         for fn_builder in &program_ctors {
-            ctor_dispatches.push(fn_builder.ctor_branch_impl(
-                program_type_path,
-                &input_ident,
-                program_ident,
-            ));
+            if fn_builder.has_scale_codec() {
+                ctor_dispatches.push(fn_builder.ctor_branch_impl(
+                    program_type_path,
+                    &input_ident,
+                    program_ident,
+                ));
+            }
             ctor_params_structs.push(fn_builder.ctor_params_struct());
             ctor_meta_variants.push(fn_builder.ctor_meta_variant());
         }
@@ -769,6 +776,7 @@ impl FnBuilder<'_> {
         let params_struct_ident = &self.params_struct_ident;
         let params_struct_members = self.params().map(|(ident, ty)| quote!(#ident: #ty));
         let entry_id = &self.entry_id;
+        let decode_disabled = (!self.has_scale_codec()).then(|| quote!(decode = false,));
 
         quote! {
             #sails_path::invocation_io!(
@@ -776,6 +784,7 @@ impl FnBuilder<'_> {
                     #(pub(super) #params_struct_members,)*
                 },
                 entry_id = #entry_id,
+                #decode_disabled
             );
         }
     }
@@ -794,17 +803,29 @@ impl FnBuilder<'_> {
         #[cfg(not(feature = "ethexe"))]
         let payable_ann: Option<TokenStream2> = None;
 
+        #[cfg(feature = "ethexe")]
+        let codec_ann: Option<TokenStream2> =
+            match (self.has_scale_codec(), self.has_ethabi_codec()) {
+                (true, false) => Some(quote!(#[annotate(codec = "scale")])),
+                (false, true) => Some(quote!(#[annotate(codec = "ethabi")])),
+                _ => None,
+            };
+        #[cfg(not(feature = "ethexe"))]
+        let codec_ann: Option<TokenStream2> = None;
+
         if let Some(err_ty) = &self.error_type {
             let err_ty = shared::replace_any_lifetime_with_static(err_ty.clone());
             quote! {
                 #( #ctor_docs_attrs )*
                 #payable_ann
+                #codec_ann
                 #ctor_route(#params_struct_ident, #err_ty)
             }
         } else {
             quote! {
                 #( #ctor_docs_attrs )*
                 #payable_ann
+                #codec_ann
                 #ctor_route(#params_struct_ident)
             }
         }

--- a/rs/macros/core/src/program/mod.rs
+++ b/rs/macros/core/src/program/mod.rs
@@ -73,18 +73,20 @@ struct ProgramBuilder {
     program_impl: ItemImpl,
     program_args: ProgramArgs,
     type_constraints: Option<WhereClause>,
+    has_default_ctor_only: bool,
 }
 
 impl ProgramBuilder {
     fn new(program_impl: ItemImpl, program_args: ProgramArgs) -> Self {
         let mut program_impl = program_impl;
         let type_constraints = program_impl.generics.where_clause.take();
-        ensure_default_program_ctor(&mut program_impl);
+        let has_default_ctor_only = ensure_default_program_ctor(&mut program_impl);
 
         Self {
             program_impl,
             program_args,
             type_constraints,
+            has_default_ctor_only,
         }
     }
 
@@ -401,7 +403,7 @@ impl ProgramBuilder {
         let mut ctor_params_structs = Vec::with_capacity(program_ctors.len());
         let mut ctor_meta_variants = Vec::with_capacity(program_ctors.len());
 
-        for fn_builder in program_ctors {
+        for fn_builder in &program_ctors {
             ctor_dispatches.push(fn_builder.ctor_branch_impl(
                 program_type_path,
                 &input_ident,
@@ -425,10 +427,34 @@ impl ProgramBuilder {
             }
         };
 
+        // For programs with no user-defined constructors, also accept an empty payload.
+        // The default create() takes no arguments and is idempotent, so an empty slice is
+        // unambiguous: it cannot be confused with any real constructor message.
+        let empty_input_guard = if self.has_default_ctor_only {
+            let fn_builder = program_ctors
+                .first()
+                .expect("default ctor must exist when has_default_ctor_only is true");
+            let ctor_ident = fn_builder.ident;
+            let params_struct_ident = &fn_builder.params_struct_ident;
+            quote! {
+                if #input_ident.is_empty() {
+                    #sails_path::program_ctor!(
+                        #program_ident = #program_type_path :: #ctor_ident (),
+                        params_struct = meta_in_program::#params_struct_ident
+                    );
+                    return;
+                }
+            }
+        } else {
+            quote!()
+        };
+
         let init_fn = quote! {
             #[unsafe(no_mangle)]
             extern "C" fn init() {
                 let mut #input_ident: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+
+                #empty_input_guard
 
                 #solidity_init
 
@@ -542,7 +568,7 @@ fn gen_gprogram_impl(program_impl: ItemImpl, program_args: ProgramArgs) -> Token
     )
 }
 
-fn ensure_default_program_ctor(program_impl: &mut ItemImpl) {
+fn ensure_default_program_ctor(program_impl: &mut ItemImpl) -> bool {
     let sails_path = &sails_paths::sails_path_or_default(None);
     if discover_program_ctors(program_impl, sails_path).is_empty() {
         program_impl.items.push(ImplItem::Fn(parse_quote!(
@@ -550,7 +576,9 @@ fn ensure_default_program_ctor(program_impl: &mut ItemImpl) {
                 Default::default()
             }
         )));
+        return true;
     }
+    false
 }
 
 fn discover_program_ctors<'a>(

--- a/rs/macros/core/tests/snapshots/gprogram__generates_async_main_with_handle_reply.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_async_main_with_handle_reply.snap
@@ -30,6 +30,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -59,6 +59,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_services_with_unwrap_result.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_services_with_unwrap_result.snap
@@ -59,6 +59,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_single_service_with_non_empty_route.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_single_service_with_non_empty_route.snap
@@ -42,6 +42,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_crate_path.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_crate_path.snap
@@ -29,6 +29,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rename::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(header) = <sails_rename::meta::SailsMessageHeader as sails_rename::Decode>::decode(
             &mut input,
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_gprogram_attributes.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_gprogram_attributes.snap
@@ -29,6 +29,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_payable.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_payable.snap
@@ -29,6 +29,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_for_no_ctor.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_for_no_ctor.snap
@@ -29,6 +29,13 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn init() {
         let mut input: &[u8] = &gstd::msg::load_bytes().expect("Failed to read input");
+        if input.is_empty() {
+            sails_rs::program_ctor!(
+                PROGRAM = MyProgram::create(), params_struct =
+                meta_in_program::__CreateParams
+            );
+            return;
+        }
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input,
         ) {

--- a/rs/src/solidity.rs
+++ b/rs/src/solidity.rs
@@ -95,6 +95,31 @@ macro_rules! const_concat_slices {
     }};
 }
 
+/// Compile-time check that all 4-byte Solidity selectors in `sigs` are unique.
+///
+/// Selectors are derived from the first 4 bytes of Keccak-256 of the method
+/// signature. Because dispatch uses `.position(..)` (first-match), a collision
+/// would silently route messages for a later method to the first matching
+/// entry. Enforce uniqueness at macro-expansion time so an offending program
+/// fails to compile rather than mis-dispatches at runtime.
+pub const fn assert_unique_selectors(sigs: &[[u8; 4]]) {
+    let mut i = 0;
+    while i < sigs.len() {
+        let mut j = i + 1;
+        while j < sigs.len() {
+            assert!(
+                !(sigs[i][0] == sigs[j][0]
+                    && sigs[i][1] == sigs[j][1]
+                    && sigs[i][2] == sigs[j][2]
+                    && sigs[i][3] == sigs[j][3]),
+                "duplicate 4-byte Solidity selector detected"
+            );
+            j += 1;
+        }
+        i += 1;
+    }
+}
+
 pub struct ConstProgramMeta<T>(marker::PhantomData<T>);
 
 impl<T> ConstProgramMeta<T>
@@ -375,6 +400,19 @@ mod tests {
             solidity::ConstProgramMeta::<Prg>::ctor_callback_sigs();
         let sig_ctor = selector("replyOn_create(bytes32)");
         assert_eq!(CTOR_CALLBACK_SIGS[0], sig_ctor.as_slice());
+    }
+
+    #[test]
+    fn assert_unique_selectors_passes_on_unique() {
+        const _: () = assert_unique_selectors(&[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]);
+        assert_unique_selectors(&[]);
+        assert_unique_selectors(&[[0, 0, 0, 0]]);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate 4-byte Solidity selector detected")]
+    fn assert_unique_selectors_detects_duplicate() {
+        assert_unique_selectors(&[[1, 2, 3, 4], [9, 9, 9, 9], [1, 2, 3, 4]]);
     }
 
     #[test]


### PR DESCRIPTION
Resolves #1356 