### PR TITLE
fix: IDL Git includes & Fs includes security

### DIFF
--- a/rs/client-gen-js/src/lib.rs
+++ b/rs/client-gen-js/src/lib.rs
@@ -104,8 +104,7 @@ mod tests {
     fn test_js_generator_includes() {
         let path = "tests/idls/includes/main.idl";
         let fs_loader = FsLoader::with_root("tests/idls/includes");
-        let result =
-            preprocess::preprocess(path, &[&fs_loader]).expect("Failed to preprocess IDL");
+        let result = preprocess::preprocess(path, &[&fs_loader]).expect("Failed to preprocess IDL");
 
         assert!(result.contains("struct ResultData"));
         assert!(result.contains("enum Error"));

--- a/rs/client-gen-js/src/lib.rs
+++ b/rs/client-gen-js/src/lib.rs
@@ -55,7 +55,8 @@ impl<'a> JsClientGenerator<IdlPath<'a>> {
     pub fn generate(self) -> Result<String> {
         let idl_path = self.idl.0;
         let path_str = idl_path.to_string_lossy();
-        let idl = preprocess::preprocess(&path_str, &[&FsLoader, &GitLoader])
+        let fs_loader = FsLoader::for_entry(idl_path);
+        let idl = preprocess::preprocess(&path_str, &[&fs_loader, &GitLoader])
             .with_context(|| format!("Failed to preprocess IDL from {}", idl_path.display()))?;
         self.with_idl(&idl).generate()
     }
@@ -102,7 +103,9 @@ mod tests {
     #[test]
     fn test_js_generator_includes() {
         let path = "tests/idls/includes/main.idl";
-        let result = preprocess::preprocess(path, &[&FsLoader]).expect("Failed to preprocess IDL");
+        let fs_loader = FsLoader::with_root("tests/idls/includes");
+        let result =
+            preprocess::preprocess(path, &[&fs_loader]).expect("Failed to preprocess IDL");
 
         assert!(result.contains("struct ResultData"));
         assert!(result.contains("enum Error"));

--- a/rs/client-gen-v2/src/lib.rs
+++ b/rs/client-gen-v2/src/lib.rs
@@ -103,7 +103,8 @@ impl<'ast> ClientGenerator<'ast, IdlPath<'ast>> {
         let idl_path = self.idl.0;
 
         let path_str = idl_path.to_string_lossy();
-        let idl = preprocess::preprocess(&path_str, &[&FsLoader, &GitLoader])
+        let fs_loader = FsLoader::for_entry(idl_path);
+        let idl = preprocess::preprocess(&path_str, &[&fs_loader, &GitLoader])
             .with_context(|| format!("Failed to open {} for reading", idl_path.display()))?;
 
         self.with_idl(&idl)
@@ -116,7 +117,8 @@ impl<'ast> ClientGenerator<'ast, IdlPath<'ast>> {
         let idl_path = self.idl.0;
 
         let path_str = idl_path.to_string_lossy();
-        let idl = preprocess::preprocess(&path_str, &[&FsLoader, &GitLoader])
+        let fs_loader = FsLoader::for_entry(idl_path);
+        let idl = preprocess::preprocess(&path_str, &[&fs_loader, &GitLoader])
             .with_context(|| format!("Failed to open {} for reading", idl_path.display()))?;
 
         self.with_idl(&idl)
@@ -222,8 +224,9 @@ mod tests {
     #[test]
     fn test_resolve_idl_from_path() {
         let path = "tests/idls/recursive_main.idl";
+        let fs_loader = FsLoader::with_root("tests/idls");
         let result =
-            preprocess::preprocess(path, &[&FsLoader]).expect("Failed to resolve nested IDL");
+            preprocess::preprocess(path, &[&fs_loader]).expect("Failed to resolve nested IDL");
 
         assert!(result.contains("service Leaf"));
         assert!(result.contains("service Middle"));
@@ -233,8 +236,9 @@ mod tests {
     #[test]
     fn test_resolve_nested_idl() {
         let path = "tests/idls/nested/main.idl";
+        let fs_loader = FsLoader::with_root("tests/idls/nested");
         let result =
-            preprocess::preprocess(path, &[&FsLoader]).expect("Failed to resolve nested IDL");
+            preprocess::preprocess(path, &[&fs_loader]).expect("Failed to resolve nested IDL");
 
         assert!(result.contains("service A"));
         assert!(result.contains("service B"));
@@ -252,7 +256,8 @@ mod tests {
     #[ignore]
     fn test_git_include_demo() {
         let path = "tests/idls/git_include/main.idl";
-        let result = preprocess::preprocess(path, &[&FsLoader, &GitLoader])
+        let fs_loader = FsLoader::with_root("tests/idls/git_include");
+        let result = preprocess::preprocess(path, &[&fs_loader, &GitLoader])
             .expect("Failed to preprocess git include chain");
 
         let doc = sails_idl_parser_v2::parse_idl(&result)

--- a/rs/idl-parser-v2/src/preprocess/fs.rs
+++ b/rs/idl-parser-v2/src/preprocess/fs.rs
@@ -1,17 +1,75 @@
+use super::path_utils::is_absolute_like;
 use super::{IdlLoader, IdlSource};
 use crate::error::{Error, Result};
 use alloc::format;
 use alloc::string::{String, ToString};
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 /// Loads IDL files from the local file system.
-pub struct FsLoader;
+///
+/// In **strict** mode ([`FsLoader::new`]) include paths must be simple
+/// relative paths inside the including file's directory — `..`, absolute,
+/// and drive-prefix paths are rejected at `resolve()`.
+///
+/// In **sandboxed** mode ([`FsLoader::with_root`] / [`FsLoader::for_entry`])
+/// `..` traversal is allowed; `load()` then canonicalizes the resolved path
+/// and verifies it stays under the configured root. The root itself is
+/// canonicalized once at construction.
+#[derive(Debug, Default, Clone)]
+pub struct FsLoader {
+    root: Option<PathBuf>,
+}
+
+impl FsLoader {
+    pub const fn new() -> Self {
+        Self { root: None }
+    }
+
+    /// Sandbox includes under `root`. An empty path (e.g. from
+    /// `Path::parent()` on a bare filename) is normalized to `"."`,
+    /// otherwise the trusted-root check would be vacuous against
+    /// `starts_with("")`. The root is canonicalized eagerly so repeated
+    /// includes don't pay the syscall cost; if canonicalization fails the
+    /// original path is kept and the error is surfaced from `load()`.
+    pub fn with_root(root: impl Into<PathBuf>) -> Self {
+        let mut root: PathBuf = root.into();
+        if root.as_os_str().is_empty() {
+            root = PathBuf::from(".");
+        }
+        let canonical = root.canonicalize().unwrap_or(root);
+        Self {
+            root: Some(canonical),
+        }
+    }
+
+    /// Sandbox using the parent directory of `entry` as the root — what
+    /// generators want for an entry-point IDL.
+    pub fn for_entry(entry: &Path) -> Self {
+        Self::with_root(entry.parent().unwrap_or(Path::new(".")))
+    }
+}
 
 impl IdlLoader for FsLoader {
     fn load(&self, path: &str) -> Result<IdlSource> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| Error::Preprocess(format!("Failed to read IDL file at '{path}': {e}")))?;
+        if let Some(canonical_root) = &self.root {
+            let canonical = Path::new(path)
+                .canonicalize()
+                .map_err(|e| read_error(path, e))?;
+            if !canonical.starts_with(canonical_root) {
+                return Err(Error::Preprocess(format!(
+                    "IDL include '{path}' escapes the trusted root '{}'",
+                    canonical_root.display()
+                )));
+            }
+            let content = fs::read_to_string(&canonical).map_err(|e| read_error(path, e))?;
+            return Ok(IdlSource {
+                content,
+                id: canonical.to_string_lossy().into_owned(),
+            });
+        }
+
+        let content = fs::read_to_string(path).map_err(|e| read_error(path, e))?;
         let id = Path::new(path)
             .canonicalize()
             .map(|p| p.to_string_lossy().into_owned())
@@ -20,16 +78,249 @@ impl IdlLoader for FsLoader {
     }
 
     fn resolve(&self, base_path: &str, include_path: &str) -> Option<String> {
-        if base_path.contains("://") {
+        if base_path.contains("://") || include_path.contains("://") {
             return None;
         }
 
-        if include_path.contains("://") || include_path.starts_with('/') {
+        // `preprocess_recursive` uses `resolve(path, path)` as a "claim this
+        // path?" check before delegating to `load`. The entry path is
+        // user-supplied (trusted) and may be absolute, so it bypasses the
+        // include-style escape rules; sandboxed-mode `load` still enforces
+        // the canonical-root boundary.
+        if base_path == include_path {
             return Some(include_path.to_string());
         }
+
+        let include = Path::new(include_path);
+        if is_absolute_like(include) {
+            return None;
+        }
+        if self.root.is_none()
+            && include
+                .components()
+                .any(|c| matches!(c, Component::ParentDir))
+        {
+            return None;
+        }
+
         let base = Path::new(base_path);
         let parent = base.parent().unwrap_or(Path::new("."));
-        let resolved = parent.join(include_path);
-        Some(resolved.to_string_lossy().into_owned())
+        Some(parent.join(include_path).to_string_lossy().into_owned())
+    }
+}
+
+fn read_error(path: &str, e: std::io::Error) -> Error {
+    Error::Preprocess(format!("Failed to read IDL file at '{path}': {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FsLoader, IdlLoader};
+    use alloc::string::ToString;
+
+    // ---------- Strict mode ----------
+
+    #[test]
+    fn strict_resolves_sibling_include() {
+        let resolved = FsLoader::new()
+            .resolve("idls/main.idl", "common.idl")
+            .expect("sibling include should resolve");
+        assert_eq!(
+            std::path::Path::new(&resolved),
+            std::path::Path::new("idls").join("common.idl")
+        );
+    }
+
+    #[test]
+    fn strict_rejects_absolute_unix_path() {
+        assert!(
+            FsLoader::new()
+                .resolve("idls/main.idl", "/etc/passwd")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn strict_rejects_parent_traversal() {
+        assert!(
+            FsLoader::new()
+                .resolve("idls/main.idl", "../../secrets/private.idl")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn strict_rejects_nested_parent_traversal() {
+        assert!(
+            FsLoader::new()
+                .resolve("idls/main.idl", "sub/../../escape.idl")
+                .is_none()
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn strict_rejects_windows_absolute_path() {
+        assert!(
+            FsLoader::new()
+                .resolve("idls/main.idl", r"C:\Windows\System32\drivers\etc\hosts")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn strict_does_not_claim_url_includes() {
+        assert!(
+            FsLoader::new()
+                .resolve("idls/main.idl", "git://github.com/o/r/main/a.idl")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn strict_does_not_claim_url_bases() {
+        assert!(
+            FsLoader::new()
+                .resolve("git://github.com/o/r/main/a.idl", "common.idl")
+                .is_none()
+        );
+    }
+
+    // ---------- Sandboxed mode ----------
+
+    #[test]
+    fn sandboxed_resolves_sibling_traversal() {
+        let resolved = FsLoader::with_root("idls")
+            .resolve("idls/folder_a/a.idl", "../common.idl")
+            .expect("sibling traversal should resolve in sandboxed mode");
+        assert!(resolved.contains(".."));
+    }
+
+    #[test]
+    fn sandboxed_still_rejects_absolute_path() {
+        assert!(
+            FsLoader::with_root("idls")
+                .resolve("idls/main.idl", "/etc/passwd")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn sandboxed_still_rejects_url_includes() {
+        assert!(
+            FsLoader::with_root("idls")
+                .resolve("idls/main.idl", "git://github.com/o/r/main/a.idl")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn sandboxed_load_rejects_escape_outside_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("project");
+        let escape = tmp.path().join("secret.idl");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&escape, "leak").unwrap();
+
+        let loader = FsLoader::with_root(&root);
+        let escape_via_traversal = root.join("..").join("secret.idl");
+        let err = loader
+            .load(&escape_via_traversal.to_string_lossy())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("escapes the trusted root"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn entry_claim_test_accepts_absolute_path() {
+        let strict = FsLoader::new();
+        assert!(
+            strict
+                .resolve("/abs/path/main.idl", "/abs/path/main.idl")
+                .is_some()
+        );
+
+        let sandboxed = FsLoader::with_root("/abs/path");
+        assert!(
+            sandboxed
+                .resolve("/abs/path/main.idl", "/abs/path/main.idl")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn with_root_normalizes_empty_path() {
+        // `Path::new("foo.idl").parent()` returns `Some("")`. If `with_root`
+        // accepted that verbatim the boundary check would degenerate to
+        // `starts_with("")` → always true. Normalize to `"."` and ensure
+        // a sibling tempdir outside the CWD is still rejected.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let outside = tmp.path().join("secret.idl");
+        std::fs::write(&outside, "SECRET").unwrap();
+
+        // Use `with_root(project)` then attempt to load a sibling that is
+        // unambiguously outside the canonical root.
+        let loader = FsLoader::with_root(&project);
+        let err = loader
+            .load(&outside.to_string_lossy())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("escapes the trusted root"),
+            "expected boundary error; got: {err}"
+        );
+    }
+
+    #[test]
+    fn sandboxed_load_validates_before_reading() {
+        // Boundary check fires before any `read_to_string`: an outside file
+        // produces the boundary error, never "failed to read".
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("project");
+        let outside = tmp.path().join("secret.idl");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&outside, "SECRET").unwrap();
+
+        let err = FsLoader::with_root(&root)
+            .load(&outside.to_string_lossy())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("escapes the trusted root"),
+            "expected boundary error before any read, got: {err}"
+        );
+    }
+
+    #[test]
+    fn sandboxed_load_accepts_file_under_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("project");
+        let inner = root.join("sub").join("file.idl");
+        std::fs::create_dir_all(inner.parent().unwrap()).unwrap();
+        std::fs::write(&inner, "service Foo {}").unwrap();
+
+        let source = FsLoader::with_root(&root)
+            .load(&inner.to_string_lossy())
+            .expect("file under root should load");
+        assert_eq!(source.content, "service Foo {}");
+    }
+
+    #[test]
+    fn for_entry_uses_parent_directory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("project");
+        let entry = project.join("main.idl");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(&entry, "service Main {}").unwrap();
+
+        let source = FsLoader::for_entry(&entry)
+            .load(&entry.to_string_lossy())
+            .expect("entry under its own parent should load");
+        assert_eq!(source.content, "service Main {}");
     }
 }

--- a/rs/idl-parser-v2/src/preprocess/git.rs
+++ b/rs/idl-parser-v2/src/preprocess/git.rs
@@ -1,3 +1,4 @@
+use super::path_utils::is_absolute_like;
 use super::{IdlLoader, IdlSource};
 use crate::error::{Error, Result};
 use alloc::format;
@@ -26,13 +27,27 @@ impl IdlLoader for GitLoader {
     }
 
     fn resolve(&self, base_path: &str, include_path: &str) -> Option<String> {
+        // An absolute `git://...` include is owned by this loader regardless of
+        // the base — local IDLs are allowed to include git-hosted IDLs.
+        if include_path.starts_with("git://") {
+            return Some(include_path.to_string());
+        }
+
         if !base_path.starts_with("git://") {
             return None;
         }
 
-        if include_path.contains("://") || include_path.starts_with('/') {
-            return Some(include_path.to_string());
+        // From a git base, a non-git URL include (other scheme) is not ours.
+        if include_path.contains("://") {
+            return None;
         }
+
+        // Refuse absolute filesystem paths: a git-hosted IDL must not be able to
+        // pivot into the local filesystem via another loader (e.g. FsLoader).
+        if is_absolute_like(Path::new(include_path)) {
+            return None;
+        }
+
         let pos = base_path.rfind(['/', ':']).unwrap_or(0);
         Some(format!("{}{}", &base_path[..pos + 1], include_path))
     }
@@ -87,9 +102,11 @@ fn git_fetch(url: &str) -> Result<String> {
         return Err(Error::Preprocess("Missing file path".to_string()));
     }
 
-    if Path::new(file_path)
-        .components()
-        .any(|c| matches!(c, Component::ParentDir))
+    let file_path_obj = Path::new(file_path);
+    if is_absolute_like(file_path_obj)
+        || file_path_obj
+            .components()
+            .any(|c| matches!(c, Component::ParentDir))
     {
         return Err(Error::Preprocess(format!(
             "Path traversal detected in URL: {url}"
@@ -187,12 +204,29 @@ mod tests {
     }
 
     #[test]
-    fn test_git_resolve_absolute_fs_path() {
+    fn test_git_resolve_absolute_fs_path_rejected() {
         let loader = GitLoader;
-        let result = loader
-            .resolve("git://github.com/org/repo/main/a.idl", "/etc/types.idl")
-            .unwrap();
-        assert_eq!(result, "/etc/types.idl");
+        // Absolute include paths must not escape a git-hosted IDL into the
+        // local filesystem via another loader.
+        assert!(
+            loader
+                .resolve("git://github.com/org/repo/main/a.idl", "/etc/types.idl")
+                .is_none()
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_git_resolve_windows_absolute_fs_path_rejected() {
+        let loader = GitLoader;
+        assert!(
+            loader
+                .resolve(
+                    "git://github.com/org/repo/main/a.idl",
+                    r"C:\Windows\System32\drivers\etc\hosts",
+                )
+                .is_none()
+        );
     }
 
     #[test]
@@ -224,6 +258,10 @@ mod tests {
             (
                 "git://github.com/gear-tech/sails/master:",
                 "Missing file path",
+            ),
+            (
+                "git://github.com/gear-tech/sails/master:/etc/passwd",
+                "Path traversal detected",
             ),
         ];
 

--- a/rs/idl-parser-v2/src/preprocess/mod.rs
+++ b/rs/idl-parser-v2/src/preprocess/mod.rs
@@ -6,6 +6,8 @@ use alloc::string::{String, ToString};
 pub mod fs;
 #[cfg(feature = "std")]
 pub mod git;
+#[cfg(feature = "std")]
+mod path_utils;
 
 /// The result of loading an IDL source — content and a unique id used for deduplication.
 #[derive(Debug)]

--- a/rs/idl-parser-v2/src/preprocess/path_utils.rs
+++ b/rs/idl-parser-v2/src/preprocess/path_utils.rs
@@ -1,0 +1,12 @@
+use std::path::{Component, Path};
+
+/// `true` for paths that should be treated as absolute on either Unix or
+/// Windows: `/etc/passwd` (root-only, not `is_absolute` on Windows),
+/// `C:\...` (drive prefix), and UNC/verbatim prefixes.
+pub(super) fn is_absolute_like(p: &Path) -> bool {
+    p.is_absolute()
+        || p.has_root()
+        || p.components()
+            .next()
+            .is_some_and(|c| matches!(c, Component::Prefix(_) | Component::RootDir))
+}


### PR DESCRIPTION
Resolves:
- Git IDL includes can read arbitrary local files
- Unsandboxed IDL includes allow local file reads

## Git IDL includes can read arbitrary local files

`git://` preprocessing can cross from a remote git IDL into the local filesystem through absolute paths, and path-based client generators now opt into GitLoader by default.
GitLoader validates only '..' path components in the git file path, but it does not reject absolute paths. Because Path::join with an absolute path ignores the temporary checkout directory, a URL such as git://github.com/owner/repo/main:/etc/passwd can fetch any accessible repository and then read /etc/passwd from the local host instead of from the checkout. Separately, GitLoader::resolve explicitly returns absolute include paths from git-hosted IDLs; the shared preprocessor then recursively chooses FsLoader for that absolute path. This lets an attacker-controlled remote IDL include local files like /etc/passwd, workspace secrets, private IDL files, or CI configuration. This is a tooling/supply-chain local file disclosure issue rather than an on-chain runtime routing flaw.

## Unsandboxed IDL includes allow local file reads

IDL include support was added with an unsandboxed filesystem loader, and both Rust and JS client generators now invoke it automatically for IDL paths.
The default `FsLoader` resolves an include by simply joining it with the including file's parent directory, then reads the resulting path with `fs::read_to_string`. There is no restriction to the original IDL directory, no rejection of absolute paths, and no canonicalized `starts_with` check to prevent `../` escapes. As a result, an untrusted IDL can contain directives such as `!@include: /home/runner/work/project/.env` or `!@include: ../../.ssh/id_rsa`, causing the generator/preprocessor to read local files from the machine running the tool. The included content is appended to the preprocessed IDL returned by the public API; in generator flows it can also be exposed through parser diagnostics or generated output if the included content parses as IDL. This is a developer-tooling vulnerability rather than an on-chain runtime routing flaw, but it is security-relevant for CI, package-registry, wallet, or hosted-codegen workflows that process third-party IDL files.