### PR TITLE
fix(macros): Mutable program borrows can survive async dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,9 +829,10 @@ initiating an asynchronous call might change by the time the call completes. See
 
 > **Do not hold mutable state borrows across an `.await`.** While one message is
 > suspended, the runtime may start handling another message. If a `RefCell` write
-> guard (`.get_mut()` / `.write()`) is still alive, the second message can panic
-> with an already-borrowed error when it touches the same state. Keep the guard in
-> a smaller scope so it is dropped before awaiting.
+> guard (`.borrow_mut()`) or `StateMut` write guard (`.get_mut()` / `.write()`)
+> is still alive, the second message can panic with an already-borrowed error
+> when it touches the same state. Keep the guard in a smaller scope so it is
+> dropped before awaiting.
 >
 > For the same reason, `#[program]` service constructors must take `&self`, not
 > `&mut self`. Use interior mutability (`RefCell`, `Cell`) for mutable program

--- a/README.md
+++ b/README.md
@@ -827,6 +827,16 @@ initiating an asynchronous call might change by the time the call completes. See
 [RmrkResource](examples/rmrk/resource/app/src/services/) service's
 `add_part_to_resource` method for more details.
 
+> **Do not hold mutable state borrows across an `.await`.** While one message is
+> suspended, the runtime may start handling another message. If a `RefCell` write
+> guard (`.get_mut()` / `.write()`) is still alive, the second message can panic
+> with an already-borrowed error when it touches the same state. Keep the guard in
+> a smaller scope so it is dropped before awaiting.
+>
+> For the same reason, `#[program]` service constructors must take `&self`, not
+> `&mut self`. Use interior mutability (`RefCell`, `Cell`) for mutable program
+> state passed into services.
+
 ### Events
 
 You can find an example of how to emit events from your service in the [Counter](examples/demo/app/src/counter/)

--- a/examples/demo/app/src/lib.rs
+++ b/examples/demo/app/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
+use core::cell::{Cell, RefCell};
 use demo_walker as walker;
-use sails_rs::{cell::RefCell, prelude::*};
+use sails_rs::prelude::*;
 
 mod chaos;
 mod counter;
@@ -39,7 +40,7 @@ pub struct DemoProgram {
     // live as long as the program is available on the network.
     counter_data: RefCell<counter::CounterData>,
     validator_data: RefCell<validator::ValidatorData>,
-    ref_data: u8,
+    ref_data: Cell<u8>,
 }
 
 #[program(payable)]
@@ -57,7 +58,7 @@ impl DemoProgram {
         Self {
             counter_data: RefCell::new(counter::CounterData::new(Default::default())),
             validator_data: RefCell::new(validator::ValidatorData::new()),
-            ref_data: 42,
+            ref_data: Cell::new(42),
         }
     }
 
@@ -75,7 +76,7 @@ impl DemoProgram {
         Ok(Self {
             counter_data: RefCell::new(counter::CounterData::new(counter.unwrap_or_default())),
             validator_data: RefCell::new(validator::ValidatorData::new()),
-            ref_data: 42,
+            ref_data: Cell::new(42),
         })
     }
 
@@ -91,7 +92,7 @@ impl DemoProgram {
         Ok(Self {
             counter_data: RefCell::new(counter::CounterData::new(value)),
             validator_data: RefCell::new(validator::ValidatorData::new()),
-            ref_data: 42,
+            ref_data: Cell::new(42),
         })
     }
 
@@ -111,8 +112,8 @@ impl DemoProgram {
         dog::DogService::new(walker::WalkerService::new(dog_data()))
     }
 
-    pub fn references(&mut self) -> references::ReferenceService<'_> {
-        references::ReferenceService::new(&mut self.ref_data, "demo")
+    pub fn references(&self) -> references::ReferenceService<'_> {
+        references::ReferenceService::new(&self.ref_data, "demo")
     }
 
     pub fn this_that(&self) -> this_that::MyService {

--- a/examples/demo/app/src/references/mod.rs
+++ b/examples/demo/app/src/references/mod.rs
@@ -1,4 +1,4 @@
-use core::ptr;
+use core::{cell::Cell, ptr};
 use sails_rs::prelude::*;
 
 // This example makes use of fully incapsulated static state.
@@ -14,12 +14,12 @@ pub struct ReferenceService<'a> {
 }
 
 struct ReferenceData<'a> {
-    num: &'a mut u8,
+    num: &'a Cell<u8>,
     message: &'a str,
 }
 
 impl<'a> ReferenceService<'a> {
-    pub fn new(num: &'a mut u8, message: &'a str) -> Self {
+    pub fn new(num: &'a Cell<u8>, message: &'a str) -> Self {
         let data = ReferenceData { num, message };
         Self { data: Some(data) }
     }
@@ -60,16 +60,16 @@ impl<'t> ReferenceService<'t> {
 
     #[export]
     #[allow(static_mut_refs)]
-    pub async fn last_byte<'a>(&self) -> Option<&'a u8> {
+    pub fn last_byte<'a>(&self) -> Option<&'a u8> {
         unsafe { BYTES.last() }
     }
 
     #[export]
-    pub async fn guess_num(&mut self, number: u8) -> Result<&'t str, &'static str> {
+    pub fn guess_num(&mut self, number: u8) -> Result<&'t str, &'static str> {
         if number > 42 {
             Err("Number is too large")
-        } else if let Some(data) = &self.data.as_ref() {
-            if *data.num == number {
+        } else if let Some(data) = self.data.as_ref() {
+            if data.num.get() == number {
                 Ok(data.message)
             } else {
                 Err("Try again")
@@ -80,16 +80,16 @@ impl<'t> ReferenceService<'t> {
     }
 
     #[export]
-    pub async fn message(&self) -> Option<&'t str> {
+    pub fn message(&self) -> Option<&'t str> {
         self.data.as_ref().map(|d| d.message)
     }
 
     #[export]
-    pub async fn set_num(&mut self, number: u8) -> Result<(), &'static str> {
+    pub fn set_num(&mut self, number: u8) -> Result<(), &'static str> {
         if number > 42 {
             Err("Number is too large")
-        } else if let Some(data) = self.data.as_mut() {
-            *data.num = number;
+        } else if let Some(data) = self.data.as_ref() {
+            data.num.set(number);
             Ok(())
         } else {
             Err("Data is not set")

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
@@ -213,7 +213,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
                 let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -180,7 +180,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
                 let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
@@ -180,7 +180,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
                 let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
@@ -156,7 +156,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
                 let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
@@ -141,7 +141,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
                 let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
@@ -207,7 +207,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
                 let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
@@ -139,7 +139,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
                 let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
@@ -152,7 +152,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
                 let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
@@ -209,7 +209,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(sig) = TryInto::<[u8; 4]>::try_into(&input[..4]) {
             if let Some(idx) = __METHOD_SIGS.iter().position(|s| s == &sig) {
                 let (interface_id, entry_id, route_idx) = __METHOD_ROUTES[idx];

--- a/rs/macros/core/src/program/mod.rs
+++ b/rs/macros/core/src/program/mod.rs
@@ -116,7 +116,7 @@ impl ProgramBuilder {
                     } else {
                         abort!(
                             fn_item,
-                            "`handle_reply` function must have a single `&self` argument and no return type"
+                            "`handle_reply` function must be private and have a single `&self` argument and no return type"
                         );
                     }
                 }
@@ -163,9 +163,19 @@ impl ProgramBuilder {
         let mut route_dispatch_data = Vec::new(); // Store data for route dispatches
 
         for (idx, impl_item) in self.program_impl.items.iter().enumerate() {
-            if let ImplItem::Fn(fn_item) = impl_item
-                && service_ctor_predicate(fn_item)
-            {
+            if let ImplItem::Fn(fn_item) = impl_item {
+                if is_mut_service_ctor(fn_item) {
+                    abort!(
+                        fn_item,
+                        "service constructor must take `&self`, not `&mut self`: a `&mut self` \
+                         factory can leak an exclusive borrow of program state across an `.await`"
+                    );
+                }
+
+                if !service_ctor_predicate(fn_item) {
+                    continue;
+                }
+
                 let mut invocation_export = shared::invocation_export_or_default(fn_item);
                 let entry_id = routes.len() as u16;
 
@@ -237,7 +247,7 @@ impl ProgramBuilder {
         let handle_reply_fn = self.handle_reply_fn().map(|item_fn| {
             let handle_reply_fn_ident = &item_fn.sig.ident;
             quote! {
-                let program_ref = unsafe { #program_ident.as_mut() }.expect("Program not initialized");
+                let program_ref = unsafe { #program_ident.as_ref() }.expect("Program not initialized");
                 program_ref.#handle_reply_fn_ident();
             }
         })
@@ -335,7 +345,7 @@ impl ProgramBuilder {
 
                 let mut input = gstd::msg::load_bytes().expect("Failed to read input");
 
-                let program_ref = unsafe { #program_ident.as_mut() }.expect("Program not initialized");
+                let program_ref = unsafe { #program_ident.as_ref() }.expect("Program not initialized");
 
                 #solidity_main
 
@@ -605,17 +615,24 @@ fn program_ctor_predicate(
     false
 }
 
+fn service_ctor_receiver(fn_item: &ImplItemFn) -> Option<&Receiver> {
+    fn_item.sig.receiver().filter(|receiver| {
+        matches!(fn_item.vis, Visibility::Public(_))
+            && fn_item.sig.inputs.len() == 1
+            && !matches!(fn_item.sig.output, ReturnType::Default)
+            && receiver.reference.is_some()
+    })
+}
+
 fn service_ctor_predicate(fn_item: &ImplItemFn) -> bool {
-    matches!(fn_item.vis, Visibility::Public(_))
-        && matches!(
-            fn_item.sig.receiver(),
-            Some(Receiver {
-                reference: Some(_),
-                ..
-            })
-        )
-        && fn_item.sig.inputs.len() == 1
-        && !matches!(fn_item.sig.output, ReturnType::Default)
+    service_ctor_receiver(fn_item).is_some_and(|receiver| receiver.mutability.is_none())
+}
+
+/// Detects a public method shaped like a service constructor but taking `&mut self`.
+/// Used to emit a clear compile error instead of silently ignoring such a method
+/// (which `service_ctor_predicate` rejects).
+fn is_mut_service_ctor(fn_item: &ImplItemFn) -> bool {
+    service_ctor_receiver(fn_item).is_some_and(|receiver| receiver.mutability.is_some())
 }
 
 fn has_handle_reply_attr(fn_item: &ImplItemFn) -> bool {
@@ -845,5 +862,32 @@ mod tests {
 
         assert_eq!(discovered_services.len(), 1);
         assert!(discovered_services.contains(&String::from("public_method_returning_smth")));
+    }
+
+    #[test]
+    fn is_mut_service_ctor_detects_only_public_mut_self_factories() {
+        let program_impl: ItemImpl = syn::parse2(quote!(
+            impl MyProgram {
+                pub fn mut_factory(&mut self) -> MyService {}
+                pub fn shared_factory(&self) -> MyService {}
+                fn non_public_mut_factory(&mut self) -> MyService {}
+                pub fn mut_factory_returning_unit(&mut self) {}
+                pub fn mut_factory_with_other_params(&mut self, p1: u32) -> MyService {}
+            }
+        ))
+        .unwrap();
+
+        let detected = program_impl
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                ImplItem::Fn(fn_item) if is_mut_service_ctor(fn_item) => {
+                    Some(fn_item.sig.ident.to_string())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(detected, vec![String::from("mut_factory")]);
     }
 }

--- a/rs/macros/core/tests/snapshots/gprogram__generates_async_ctor_with_service.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_async_ctor_with_service.snap
@@ -83,7 +83,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_async_main_with_handle_reply.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_async_main_with_handle_reply.snap
@@ -67,7 +67,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {
@@ -87,7 +87,7 @@ pub mod wasm {
         if MyProgram::ASYNC {
             gstd::handle_reply_with_hook();
         }
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         program_ref.handle_reply();
     }
     #[unsafe(no_mangle)]

--- a/rs/macros/core/tests/snapshots/gprogram__generates_ctors_meta_with_docs.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_ctors_meta_with_docs.snap
@@ -94,7 +94,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -103,7 +103,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_services_with_unwrap_result.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_services_with_unwrap_result.snap
@@ -103,7 +103,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_single_service_with_non_empty_route.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_single_service_with_non_empty_route.snap
@@ -80,7 +80,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_crate_path.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_crate_path.snap
@@ -66,7 +66,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rename::meta::SailsMessageHeader as sails_rename::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_gprogram_attributes.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_gprogram_attributes.snap
@@ -66,7 +66,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_payable.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_payable.snap
@@ -69,7 +69,7 @@ pub mod wasm {
             return;
         }
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_for_multiple_ctors.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_for_multiple_ctors.snap
@@ -88,7 +88,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_for_no_ctor.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_for_no_ctor.snap
@@ -66,7 +66,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_for_single_ctor.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_for_single_ctor.snap
@@ -69,7 +69,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_with_unwrap_result.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_with_unwrap_result.snap
@@ -90,7 +90,7 @@ pub mod wasm {
     #[unsafe(no_mangle)]
     extern "C" fn handle() {
         let mut input = gstd::msg::load_bytes().expect("Failed to read input");
-        let program_ref = unsafe { PROGRAM.as_mut() }.expect("Program not initialized");
+        let program_ref = unsafe { PROGRAM.as_ref() }.expect("Program not initialized");
         if let Ok(header) = <sails_rs::meta::SailsMessageHeader as sails_rs::Decode>::decode(
             &mut input.as_slice(),
         ) {

--- a/rs/macros/tests/ui/gprogram_fails_handle_reply_public.rs
+++ b/rs/macros/tests/ui/gprogram_fails_handle_reply_public.rs
@@ -1,0 +1,16 @@
+use sails_macros::program;
+
+struct MyProgram;
+
+#[program]
+impl MyProgram {
+    pub fn new() -> Self {
+        Self
+    }
+
+    #[handle_reply]
+    pub fn handle_reply(&self) {}
+}
+
+#[tokio::main]
+async fn main() {}

--- a/rs/macros/tests/ui/gprogram_fails_handle_reply_public.stderr
+++ b/rs/macros/tests/ui/gprogram_fails_handle_reply_public.stderr
@@ -1,0 +1,5 @@
+error: `handle_reply` function must be private and have a single `&self` argument and no return type
+  --> tests/ui/gprogram_fails_handle_reply_public.rs:12:5
+   |
+12 |     pub fn handle_reply(&self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rs/macros/tests/ui/gprogram_fails_handle_reply_signature.stderr
+++ b/rs/macros/tests/ui/gprogram_fails_handle_reply_signature.stderr
@@ -1,4 +1,4 @@
-error: `handle_reply` function must have a single `&self` argument and no return type
+error: `handle_reply` function must be private and have a single `&self` argument and no return type
   --> tests/ui/gprogram_fails_handle_reply_signature.rs:12:5
    |
 12 |     fn handle_reply() {}

--- a/rs/macros/tests/ui/gprogram_fails_mut_service_ctor.rs
+++ b/rs/macros/tests/ui/gprogram_fails_mut_service_ctor.rs
@@ -1,0 +1,19 @@
+use sails_macros::program;
+
+struct MyService;
+
+struct MyProgram;
+
+#[program]
+impl MyProgram {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn service(&mut self) -> MyService {
+        MyService
+    }
+}
+
+#[tokio::main]
+async fn main() {}

--- a/rs/macros/tests/ui/gprogram_fails_mut_service_ctor.stderr
+++ b/rs/macros/tests/ui/gprogram_fails_mut_service_ctor.stderr
@@ -1,0 +1,7 @@
+error: service constructor must take `&self`, not `&mut self`: a `&mut self` factory can leak an exclusive borrow of program state across an `.await`
+  --> tests/ui/gprogram_fails_mut_service_ctor.rs:13:5
+   |
+13 | /     pub fn service(&mut self) -> MyService {
+14 | |         MyService
+15 | |     }
+   | |_____^


### PR DESCRIPTION
Resolves:

Generated programs can now services borrowing program state mutably, and the generated async dispatch may hold those mutable borrows across `.await` while future messages can obtain new mutable borrows from the same `static mut PROGRAM`.

Sails stores the program instance in a generated `static mut PROGRAM`. The generated dispatcher then constructs a service from that mutable program reference and awaits `service.try_handle(...)`. Service dispatch also awaits async handlers. A service factory such as `fn accounts(&mut self) -> AccountsService<'_>` can return a service holding `&mut` references into the program. If an async handler on that service awaits a reply or other future, the future can retain the mutable reference while the Gear/Sails async message loop later processes another message and obtains another `&mut PROGRAM`. This violates Rust's exclusive aliasing assumptions for `&mut` references and can also create application-level reentrancy/state races, for example two withdrawals using stale state around an await. The issue is introduced by the `&mut self` service exposure support and the corresponding generated mutable borrow of the global program instance.
