### PR TITLE
fix(js): Unescaped IDL docs allow TypeScript code injection

### DIFF
--- a/js/cli/src/generate/format.ts
+++ b/js/cli/src/generate/format.ts
@@ -4,7 +4,9 @@ export function formatDocs(docs: string): string[] {
 
   const lines = docs.split('\n');
   for (const line of lines) {
-    result.push(` * ${line.trim()}`);
+    // Escape comment terminators so doc text cannot break out of the
+    // generated JSDoc block and inject executable TypeScript.
+    result.push(` * ${line.trim().replaceAll('*/', String.raw`*\/`)}`);
   }
 
   return ['/**', ...result, '*/'];

--- a/js/cli/test/generator.test.js
+++ b/js/cli/test/generator.test.js
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { ProjectBuilder } from '../build/index.js';
 import { Sails } from '../../lib';
 import { SailsIdlParser } from '../../parser/lib';
+import { formatDocs } from '../build/generate/format.js';
 
 const __filename = fileURLToPath(import.meta.url);
 
@@ -36,5 +37,9 @@ describe('generator', () => {
 
     const types = generator.generateTypes();
     expect(types).toBeNull();
+  });
+
+  test('escapes comment terminators in docs', () => {
+    expect(formatDocs('*/;throw new Error("x");/*')).toEqual(['/**', ' * *\\/;throw new Error("x");/*', '*/']);
   });
 });

--- a/rs/client-gen-js/src/helpers.rs
+++ b/rs/client-gen-js/src/helpers.rs
@@ -10,7 +10,9 @@ pub(crate) fn push_doc(tokens: &mut Tokens, docs: &[String]) {
     tokens.append("/**");
     tokens.push();
     for line in docs {
-        tokens.append(format!(" * {}", line));
+        // Escape comment terminators so doc text cannot break out of the
+        // generated JSDoc block and inject executable TypeScript.
+        tokens.append(format!(" * {}", line.replace("*/", "*\\/")));
         tokens.push();
     }
     tokens.append(" */");
@@ -50,5 +52,20 @@ pub(crate) fn payload_type_expr(params: &[ast::FuncParam], resolver_expr: &str) 
         format!(
             "{resolver_expr}.getTypeDeclString({{\"kind\":\"tuple\",\"types\":[{tuple_types}]}})"
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_doc_escapes_comment_terminators() {
+        let mut tokens = Tokens::new();
+        push_doc(&mut tokens, &[r#"*/;throw new Error("x");/*"#.to_string()]);
+        let rendered = tokens.to_string().expect("tokens should render");
+        // The only `*/` left must be the JSDoc block's own terminator.
+        assert_eq!(rendered.matches("*/").count(), 1);
+        assert!(rendered.contains(r"*\/;throw"));
     }
 }


### PR DESCRIPTION
Resolves:

Untrusted IDL docs are emitted into generated TypeScript source as raw JSDoc comment contents. The generator needs to sanitize comment terminators, for example by replacing `*/` with `*\/`, or otherwise render documentation through a safe comment/string escaping routine.

Because IDL documentation lines are parsed from `///[^\n]*`, an attacker-controlled IDL can contain a line such as `/// */ import { execSync } from 'node:child_process'; execSync('...'); /*`. The generated output becomes a closed JSDoc comment followed by attacker-controlled TypeScript and then a reopened comment that is closed by the generator's final `*/`. This can inject top-level code before generated types, or class-body code such as `static { ... }` before generated service methods. The code would run when the generated library is imported or otherwise used by a downstream project.