### PR TITLE
fix: Ordering `#[sails_type]`  and  `#[event]`

### DIFF
--- a/rs/cli/templates/app/src/lib.askama
+++ b/rs/cli/templates/app/src/lib.askama
@@ -29,8 +29,8 @@ pub struct {{ service_name }}State {
 }
 
 /// Events emitted by the `{{ service_name }}` service.
-#[sails_rs::sails_type]
 #[sails_rs::event]
+#[sails_rs::sails_type]
 pub enum {{ service_name }}Events {
     CalledBy { caller: {% if eth %}Address{% else %}ActorId{% endif %} },
 }

--- a/rs/macros/core/src/sails_type/mod.rs
+++ b/rs/macros/core/src/sails_type/mod.rs
@@ -28,6 +28,28 @@ pub fn sails_type(attrs: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let sails_path: Path = sails_path_or_default(args.path);
+
+    // Detect wrong macro order: #[sails_rs::sails_type] outer, #[sails_rs::event] inner.
+    // The event macro must sort variants before derives run, so it must appear first.
+    let sails_crate = sails_path.segments.first().map(|s| &s.ident);
+    if let Item::Enum(item_enum) = &parsed
+        && item_enum.attrs.iter().any(|attr| {
+            let path = attr.path();
+            path.is_ident("event")
+                || path.segments.last().is_some_and(|last| {
+                    last.ident == "event"
+                        && sails_crate
+                            .zip(path.segments.first())
+                            .is_some_and(|(sc, first)| sc == &first.ident)
+                })
+        })
+    {
+        abort!(
+            item_enum,
+            "#[sails_rs::event] must appear before #[sails_rs::sails_type], not after; \
+                 swap the attribute order to avoid a hash mismatch"
+        );
+    }
     let scale_codec = quote! { #sails_path::scale_codec };
     let type_info = quote! { #sails_path::type_info };
 

--- a/rs/macros/src/lib.rs
+++ b/rs/macros/src/lib.rs
@@ -265,7 +265,19 @@ pub fn event(args: TokenStream, input: TokenStream) -> TokenStream {
 /// pub struct LegacyType { pub a: u32 }
 /// ```
 ///
-/// Composes with `#[event]` in any order — the two macros are orthogonal.
+/// # Ordering with `#[event]`
+///
+/// When applied to an event enum, `#[event]` **must** appear _before_ `#[sails_type]`:
+///
+/// ```rust,ignore
+/// #[sails_rs::event]  // correct: sorts variants first
+/// #[sails_rs::sails_type]
+/// pub enum MyEvents { Transferred, Approved }
+/// ```
+///
+/// Placing `#[sails_type]` first is a compile error. `#[event]` must sort variants
+/// alphabetically before `ReflectHash` (added by `#[sails_type]`) runs its derive;
+/// the reversed order would produce a hash inconsistent with the IDL.
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn sails_type(args: TokenStream, item: TokenStream) -> TokenStream {

--- a/rs/macros/tests/ui/sails_type_fails_event_wrong_order.rs
+++ b/rs/macros/tests/ui/sails_type_fails_event_wrong_order.rs
@@ -1,0 +1,10 @@
+use sails_rs::prelude::*;
+
+#[sails_type]
+#[event]
+pub enum MyEvents {
+    Transfer { from: ActorId, amount: u128 },
+    Approval(ActorId),
+}
+
+fn main() {}

--- a/rs/macros/tests/ui/sails_type_fails_event_wrong_order.stderr
+++ b/rs/macros/tests/ui/sails_type_fails_event_wrong_order.stderr
@@ -1,0 +1,9 @@
+error: #[sails_rs::event] must appear before #[sails_rs::sails_type], not after; swap the attribute order to avoid a hash mismatch
+ --> tests/ui/sails_type_fails_event_wrong_order.rs:4:1
+  |
+4 | / #[event]
+5 | | pub enum MyEvents {
+6 | |     Transfer { from: ActorId, amount: u128 },
+7 | |     Approval(ActorId),
+8 | | }
+  | |_^

--- a/rs/reflect-hash/derive/src/lib.rs
+++ b/rs/reflect-hash/derive/src/lib.rs
@@ -37,8 +37,10 @@ use syn::{
 ///
 /// ## Enums
 ///
-/// The final hash is `keccak256(variant_hash_0 || variant_hash_1 || ... || variant_hash_N)`
-/// where variants are processed in declaration order.
+/// The final hash is `keccak256(variant_hash_0 || variant_hash_1 || ... || variant_hash_N)`.
+/// Variants are processed in **declaration order** unless the enum also carries an `#[event]`
+/// (or `#[sails_rs::event]`) attribute, in which case variants are sorted case-insensitively by
+/// name to match IDL normalization.
 ///
 /// - **Unit variant** `Transferred` → `keccak256(b"Transferred")`
 /// - **Tuple variant** `Approved(ActorId, u128)` → `keccak256(b"Approved" || ActorId::HASH || u128::HASH)`
@@ -114,7 +116,19 @@ fn derive_reflect_hash_impl(input: DeriveInput) -> SynResult<TokenStream2> {
         Data::Struct(data_struct) => {
             generate_struct_hash(ty_name, &data_struct.fields, &crate_name)?
         }
-        Data::Enum(data_enum) => generate_enum_hash(&data_enum.variants, &crate_name)?,
+        Data::Enum(data_enum) => {
+            // When an event macro is present, variants must be hashed in alphabetical order
+            // to match IDL normalization, regardless of which macro ran first.
+            let sort_alphabetically = input.attrs.iter().any(|attr| {
+                let path = attr.path();
+                path.is_ident("event")
+                    || path
+                        .segments
+                        .last()
+                        .map_or(false, |s| s.ident == "event" && path.segments.len() == 2)
+            });
+            generate_enum_hash(&data_enum.variants, &crate_name, sort_alphabetically)?
+        }
         Data::Union(_) => {
             return Err(Error::new_spanned(
                 ty_name,
@@ -130,7 +144,6 @@ fn derive_reflect_hash_impl(input: DeriveInput) -> SynResult<TokenStream2> {
     })
 }
 
-// TODO: #1125
 /// Look for `#[reflect_hash(crate = ...)]` attribute and return the path.
 /// If not found, use proc-macro-crate to detect the crate name.
 fn reflect_hash_crate_path(attrs: &[Attribute]) -> SynResult<TokenStream2> {
@@ -222,13 +235,22 @@ fn generate_struct_hash(
 }
 
 /// Generates hash computation for an enum.
+///
+/// When `sort_alphabetically` is true (i.e. the enum is an event type), variants are hashed in
+/// case-insensitive alphabetical order so the result matches IDL normalization.
 fn generate_enum_hash(
     variants: &Punctuated<Variant, token::Comma>,
     crate_name: &TokenStream2,
+    sort_alphabetically: bool,
 ) -> SynResult<TokenStream2> {
     let mut variant_hash_computations = Vec::new();
 
-    for variant in variants {
+    let mut variant_refs: Vec<&Variant> = variants.iter().collect();
+    if sort_alphabetically {
+        variant_refs.sort_by_key(|v| v.ident.to_string().to_lowercase());
+    }
+
+    for variant in variant_refs {
         let variant_hash = generate_struct_hash(&variant.ident, &variant.fields, crate_name)?;
         variant_hash_computations.push(variant_hash);
     }

--- a/rs/reflect-hash/derive/src/lib.rs
+++ b/rs/reflect-hash/derive/src/lib.rs
@@ -120,12 +120,10 @@ fn derive_reflect_hash_impl(input: DeriveInput) -> SynResult<TokenStream2> {
             // When an event macro is present, variants must be hashed in alphabetical order
             // to match IDL normalization, regardless of which macro ran first.
             let sort_alphabetically = input.attrs.iter().any(|attr| {
-                let path = attr.path();
-                path.is_ident("event")
-                    || path
-                        .segments
-                        .last()
-                        .map_or(false, |s| s.ident == "event" && path.segments.len() == 2)
+                attr.path()
+                    .segments
+                    .last()
+                    .is_some_and(|s| s.ident == "event")
             });
             generate_enum_hash(&data_enum.variants, &crate_name, sort_alphabetically)?
         }


### PR DESCRIPTION
Fixing a service `interface_id` hash mismatch caused by wrong macro ordering on event enums.

All changes are done and tested