### PR TITLE
fix: reject trailing invocation bytes

### DIFF
--- a/examples/inspector/app/src/lib.rs
+++ b/examples/inspector/app/src/lib.rs
@@ -35,6 +35,7 @@ impl InspectorService {
 
     /// Proxy call to validator.validate_even(7)
     #[export(unwrap_result)]
+    #[allow(clippy::result_unit_err)]
     pub async fn test_even_panic(&self) -> Result<u32, ()> {
         self.validator.validate_even(7).await.unwrap()
     }

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__filters_program_level_dispatch_by_transport.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__filters_program_level_dispatch_by_transport.snap
@@ -142,7 +142,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 1u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
@@ -127,8 +127,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -144,8 +144,8 @@ pub mod wasm {
                 }
                 1u16 => {
                     let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_ctors_meta_with_docs.snap
@@ -126,7 +126,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (p1, p2): (u32, String) = sails::Decode::decode(&mut input)
+                    let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -141,7 +143,9 @@ pub mod wasm {
                     )
                 }
                 1u16 => {
-                    let (p2, p1): (String, u32) = sails::Decode::decode(&mut input)
+                    let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -131,7 +131,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_services_with_unwrap_result.snap
@@ -131,7 +131,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_for_single_service_with_non_empty_route.snap
@@ -117,7 +117,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
@@ -104,8 +104,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (): () = sails_rename::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails_rename::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_handle_with_crate_path.snap
@@ -103,7 +103,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails_rename::Decode::decode(&mut input)
+                    let (): () = sails_rename::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails_rename::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
@@ -120,7 +120,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (p1, p2): (u32, String) = sails::Decode::decode(&mut input)
+                    let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -135,7 +137,9 @@ pub mod wasm {
                     )
                 }
                 1u16 => {
-                    let (p2, p1): (String, u32) = sails::Decode::decode(&mut input)
+                    let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_multiple_ctors.snap
@@ -121,8 +121,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -138,8 +138,8 @@ pub mod wasm {
                 }
                 1u16 => {
                     let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_no_ctor.snap
@@ -101,7 +101,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
@@ -99,7 +99,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (p1, p2): (u32, String) = sails::Decode::decode(&mut input)
+                    let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_for_single_ctor.snap
@@ -100,8 +100,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
@@ -122,7 +122,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (p1, p2): (u32, String) = sails::Decode::decode(&mut input)
+                    let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -137,7 +139,9 @@ pub mod wasm {
                     )
                 }
                 1u16 => {
-                    let (p2, p1): (String, u32) = sails::Decode::decode(&mut input)
+                    let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/program_insta__generates_init_with_unwrap_result.snap
@@ -123,8 +123,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -140,8 +140,8 @@ pub mod wasm {
                 }
                 1u16 => {
                     let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_allow_attrs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_allow_attrs.snap
@@ -69,7 +69,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -107,7 +107,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_basics.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_basics.snap
@@ -66,7 +66,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -104,7 +104,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_crate_path.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_crate_path.snap
@@ -66,7 +66,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails_rename::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails_rename::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails_rename::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -104,7 +104,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails_rename::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails_rename::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails_rename::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_docs.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_docs.snap
@@ -69,7 +69,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -107,7 +107,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_events.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_events.snap
@@ -70,7 +70,7 @@ impl MyServiceWithEventsExposure<MyServiceWithEvents> {
                 0u16,
             ) if id
                 == <self::MyServiceWithEvents as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: my_service_with_events_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: my_service_with_events_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -96,7 +96,7 @@ impl MyServiceWithEventsExposure<MyServiceWithEvents> {
                 1u16,
             ) if id
                 == <self::MyServiceWithEvents as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: my_service_with_events_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: my_service_with_events_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_dual_export.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_dual_export.snap
@@ -59,7 +59,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DualMethodParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DualMethodParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_scale_only.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_explicit_scale_only.snap
@@ -59,7 +59,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ScaleMethodParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ScaleMethodParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_export.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_export.snap
@@ -70,7 +70,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -108,7 +108,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoSomethingParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoSomethingParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends.snap
@@ -95,7 +95,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends_and_lifetimes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_extends_and_lifetimes.snap
@@ -87,7 +87,7 @@ impl<'a> ExtendedWithLifetimeExposure<ExtendedWithLifetime<'a>> {
                 == <self::ExtendedWithLifetime<
                     'a,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: extended_with_lifetime_meta::__ExtendedNameParams = sails::scale_codec::Decode::decode(
+                let request: extended_with_lifetime_meta::__ExtendedNameParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -115,7 +115,7 @@ impl<'a> ExtendedWithLifetimeExposure<ExtendedWithLifetime<'a>> {
                 == <self::ExtendedWithLifetime<
                     'a,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: extended_with_lifetime_meta::__NameParams = sails::scale_codec::Decode::decode(
+                let request: extended_with_lifetime_meta::__NameParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_events.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_events.snap
@@ -69,7 +69,7 @@ where
                     'a,
                     T,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: my_generic_events_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: my_generic_events_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_generics.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_lifetimes_and_generics.snap
@@ -68,7 +68,7 @@ where
                     T,
                     U,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_methods_with_lifetimes.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_methods_with_lifetimes.snap
@@ -93,7 +93,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 0u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__AddByteParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__AddByteParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -119,7 +119,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 1u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__BakedParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__BakedParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -145,7 +145,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 3u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__IncrParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__IncrParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -183,7 +183,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 2u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__FirstByteParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__FirstByteParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -209,7 +209,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 4u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__LastByteParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__LastByteParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_mixed_transports.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_mixed_transports.snap
@@ -80,7 +80,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DefaultBothParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DefaultBothParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -106,7 +106,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DualParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DualParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -132,7 +132,7 @@ impl SomeServiceExposure<SomeService> {
                 3u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ScaleOnlyParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ScaleOnlyParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_reply_with_value.snap
@@ -66,7 +66,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -104,7 +104,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_special_lifetimes_and_events.snap
+++ b/rs/ethexe/macros-tests/tests/snapshots/service_insta__works_with_special_lifetimes_and_events.snap
@@ -70,7 +70,7 @@ where
                     '_,
                     T,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: my_generic_events_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: my_generic_events_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/idl-ast/src/interface_id.rs
+++ b/rs/idl-ast/src/interface_id.rs
@@ -94,7 +94,7 @@ impl core::str::FromStr for InterfaceId {
         }
 
         let mut bytes = [0u8; 8];
-        for (i, chunk) in s.as_bytes().chunks_exact(2).enumerate() {
+        for (i, chunk) in s.as_bytes().as_chunks::<2>().0.iter().enumerate() {
             let hex = core::str::from_utf8(chunk).map_err(|_| "invalid UTF-8".to_string())?;
 
             bytes[i] =

--- a/rs/macros/core/src/program/mod.rs
+++ b/rs/macros/core/src/program/mod.rs
@@ -787,7 +787,7 @@ impl FnBuilder<'_> {
 
         quote!(
             #entry_id => {
-                let (#(#handler_args),*): (#(#handler_types),*)  = #sails_path::Decode::decode(&mut #input_ident)
+                let (#(#handler_args),*): (#(#handler_types),*)  = #sails_path::scale_codec::DecodeAll::decode_all(&mut #input_ident)
                     .unwrap_or_else(|_| #sails_path::gstd::unknown_input_panic("Unknown request", #input_ident));
                 #payable_check
                 #ctor_call_impl

--- a/rs/macros/core/src/service/exposure.rs
+++ b/rs/macros/core/src/service/exposure.rs
@@ -121,8 +121,9 @@ impl ServiceBuilder<'_> {
         let result_type_static = fn_builder.result_type_with_static_lifetime();
 
         quote! {
-            let request: #meta_module_ident::#params_struct_ident = #sails_path::scale_codec::Decode::decode(&mut input)
-                .expect("Failed to decode params");
+            let request: #meta_module_ident::#params_struct_ident =
+                #sails_path::scale_codec::DecodeAll::decode_all(&mut input)
+                    .expect("Failed to decode params");
             #handle_token
             if ! #sails_path::gstd::is_empty_tuple::<#result_type_static>() {
                 #sails_path::gstd::encode_invocation_payload::<#meta_module_ident::#params_struct_ident, _, _>(

--- a/rs/macros/core/tests/snapshots/gprogram__generates_async_ctor_with_service.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_async_ctor_with_service.snap
@@ -56,7 +56,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (p1, p2): (u32, String) = sails::Decode::decode(&mut input)
+                    let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_async_ctor_with_service.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_async_ctor_with_service.snap
@@ -57,8 +57,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_async_main_with_handle_reply.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_async_main_with_handle_reply.snap
@@ -48,7 +48,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_ctors_meta_with_docs.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_ctors_meta_with_docs.snap
@@ -57,7 +57,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (p1, p2): (u32, String) = sails::Decode::decode(&mut input)
+                    let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -68,7 +70,9 @@ pub mod wasm {
                     )
                 }
                 1u16 => {
-                    let (p2, p1): (String, u32) = sails::Decode::decode(&mut input)
+                    let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_ctors_meta_with_docs.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_ctors_meta_with_docs.snap
@@ -58,8 +58,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -71,8 +71,8 @@ pub mod wasm {
                 }
                 1u16 => {
                     let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_multiple_services_with_non_empty_routes.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_multiple_services_with_non_empty_routes.snap
@@ -73,7 +73,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_services_with_unwrap_result.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_services_with_unwrap_result.snap
@@ -73,7 +73,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_single_service_with_non_empty_route.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_for_single_service_with_non_empty_route.snap
@@ -60,7 +60,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_crate_path.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_crate_path.snap
@@ -47,7 +47,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails_rename::Decode::decode(&mut input)
+                    let (): () = sails_rename::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails_rename::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_crate_path.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_crate_path.snap
@@ -48,8 +48,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (): () = sails_rename::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails_rename::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_gprogram_attributes.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_gprogram_attributes.snap
@@ -47,7 +47,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_payable.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_handle_with_payable.snap
@@ -47,7 +47,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_for_multiple_ctors.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_for_multiple_ctors.snap
@@ -52,8 +52,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -65,8 +65,8 @@ pub mod wasm {
                 }
                 1u16 => {
                     let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_for_multiple_ctors.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_for_multiple_ctors.snap
@@ -51,7 +51,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (p1, p2): (u32, String) = sails::Decode::decode(&mut input)
+                    let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -62,7 +64,9 @@ pub mod wasm {
                     )
                 }
                 1u16 => {
-                    let (p2, p1): (String, u32) = sails::Decode::decode(&mut input)
+                    let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_for_no_ctor.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_for_no_ctor.snap
@@ -47,7 +47,7 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (): () = sails::Decode::decode(&mut input)
+                    let (): () = sails::scale_codec::DecodeAll::decode_all(&mut input)
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_for_single_ctor.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_for_single_ctor.snap
@@ -43,7 +43,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (p1, p2): (u32, String) = sails::Decode::decode(&mut input)
+                    let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_for_single_ctor.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_for_single_ctor.snap
@@ -44,8 +44,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_with_unwrap_result.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_with_unwrap_result.snap
@@ -54,8 +54,8 @@ pub mod wasm {
             match header.entry_id() {
                 0u16 => {
                     let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -67,8 +67,8 @@ pub mod wasm {
                 }
                 1u16 => {
                     let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
-                        &mut input,
-                    )
+                            &mut input,
+                        )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gprogram__generates_init_with_unwrap_result.snap
+++ b/rs/macros/core/tests/snapshots/gprogram__generates_init_with_unwrap_result.snap
@@ -53,7 +53,9 @@ pub mod wasm {
             }
             match header.entry_id() {
                 0u16 => {
-                    let (p1, p2): (u32, String) = sails::Decode::decode(&mut input)
+                    let (p1, p2): (u32, String) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,
@@ -64,7 +66,9 @@ pub mod wasm {
                     )
                 }
                 1u16 => {
-                    let (p2, p1): (String, u32) = sails::Decode::decode(&mut input)
+                    let (p2, p1): (String, u32) = sails::scale_codec::DecodeAll::decode_all(
+                        &mut input,
+                    )
                         .unwrap_or_else(|_| sails::gstd::unknown_input_panic(
                             "Unknown request",
                             input,

--- a/rs/macros/core/tests/snapshots/gservice__works_with_all_override_variants.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_all_override_variants.snap
@@ -101,7 +101,7 @@ impl InheritedServiceExposure<InheritedService> {
                         );
                         ID
                     } => {
-                let request: inherited_service_meta::__MethodThreeParams = sails::scale_codec::Decode::decode(
+                let request: inherited_service_meta::__MethodThreeParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -134,7 +134,7 @@ impl InheritedServiceExposure<InheritedService> {
                         );
                         ID
                     } => {
-                let request: inherited_service_meta::__RenamedByRouteParams = sails::scale_codec::Decode::decode(
+                let request: inherited_service_meta::__RenamedByRouteParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -159,7 +159,7 @@ impl InheritedServiceExposure<InheritedService> {
                 id,
                 0u16,
             ) if id == <BaseService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: inherited_service_meta::__RenamedByIdParams = sails::scale_codec::Decode::decode(
+                let request: inherited_service_meta::__RenamedByIdParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_allow_attrs.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_allow_attrs.snap
@@ -69,7 +69,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -107,7 +107,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_basics.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_basics.snap
@@ -66,7 +66,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -104,7 +104,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_crate_path.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_crate_path.snap
@@ -66,7 +66,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails_rename::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails_rename::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails_rename::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -104,7 +104,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails_rename::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails_rename::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails_rename::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_docs.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_docs.snap
@@ -69,7 +69,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -107,7 +107,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_events.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_events.snap
@@ -70,7 +70,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -96,7 +96,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_explicit_scale_transport.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_explicit_scale_transport.snap
@@ -66,7 +66,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -104,7 +104,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_export.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_export.snap
@@ -70,7 +70,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -108,7 +108,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoSomethingParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoSomethingParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_extends.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_extends.snap
@@ -95,7 +95,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_extends_and_lifetimes.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_extends_and_lifetimes.snap
@@ -87,7 +87,7 @@ impl<'a> ExtendedLifetimeExposure<ExtendedLifetime<'a>> {
                 == <self::ExtendedLifetime<
                     'a,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: extended_lifetime_meta::__ExtendedNameParams = sails::scale_codec::Decode::decode(
+                let request: extended_lifetime_meta::__ExtendedNameParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -115,7 +115,7 @@ impl<'a> ExtendedLifetimeExposure<ExtendedLifetime<'a>> {
                 == <self::ExtendedLifetime<
                     'a,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: extended_lifetime_meta::__NameParams = sails::scale_codec::Decode::decode(
+                let request: extended_lifetime_meta::__NameParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_events.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_events.snap
@@ -69,7 +69,7 @@ where
                     'a,
                     T,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: my_generic_events_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: my_generic_events_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_generics.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_lifetimes_and_generics.snap
@@ -68,7 +68,7 @@ where
                     T,
                     U,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_methods_with_lifetimes.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_methods_with_lifetimes.snap
@@ -93,7 +93,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 0u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__AddByteParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__AddByteParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -119,7 +119,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 1u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__BakedParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__BakedParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -145,7 +145,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 3u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__IncrParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__IncrParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -183,7 +183,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 2u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__FirstByteParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__FirstByteParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -209,7 +209,7 @@ impl ReferenceServiceExposure<ReferenceService> {
                 4u16,
             ) if id
                 == <self::ReferenceService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: reference_service_meta::__LastByteParams = sails::scale_codec::Decode::decode(
+                let request: reference_service_meta::__LastByteParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_mixed_methods.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_mixed_methods.snap
@@ -107,7 +107,7 @@ impl InheritedServiceExposure<InheritedService> {
                         );
                         ID
                     } => {
-                let request: inherited_service_meta::__FooParams = sails::scale_codec::Decode::decode(
+                let request: inherited_service_meta::__FooParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -133,7 +133,7 @@ impl InheritedServiceExposure<InheritedService> {
                 0u16,
             ) if id
                 == <self::InheritedService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: inherited_service_meta::__OwnFirstParams = sails::scale_codec::Decode::decode(
+                let request: inherited_service_meta::__OwnFirstParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -159,7 +159,7 @@ impl InheritedServiceExposure<InheritedService> {
                 1u16,
             ) if id
                 == <self::InheritedService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: inherited_service_meta::__OwnSecondParams = sails::scale_codec::Decode::decode(
+                let request: inherited_service_meta::__OwnSecondParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_overrides.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_overrides.snap
@@ -95,7 +95,7 @@ impl InheritedServiceExposure<InheritedService> {
                 id,
                 1u16,
             ) if id == <BaseService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: inherited_service_meta::__BarParams = sails::scale_codec::Decode::decode(
+                let request: inherited_service_meta::__BarParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -128,7 +128,7 @@ impl InheritedServiceExposure<InheritedService> {
                         );
                         ID
                     } => {
-                let request: inherited_service_meta::__FooParams = sails::scale_codec::Decode::decode(
+                let request: inherited_service_meta::__FooParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_reply_with_value.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_reply_with_value.snap
@@ -66,7 +66,7 @@ impl SomeServiceExposure<SomeService> {
                 1u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__ThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__ThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -104,7 +104,7 @@ impl SomeServiceExposure<SomeService> {
                 0u16,
             ) if id
                 == <self::SomeService as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: some_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: some_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_special_lifetimes_and_events.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_special_lifetimes_and_events.snap
@@ -70,7 +70,7 @@ where
                     '_,
                     T,
                 > as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: my_generic_events_service_meta::__DoThisParams = sails::scale_codec::Decode::decode(
+                let request: my_generic_events_service_meta::__DoThisParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/macros/core/tests/snapshots/gservice__works_with_type_generics_used_only_by_impl.snap
+++ b/rs/macros/core/tests/snapshots/gservice__works_with_type_generics_used_only_by_impl.snap
@@ -73,7 +73,7 @@ impl<M: InfallibleStorage<Item = Metadata>> VftMetadataExposure<VftMetadata<M>> 
                 0u16,
             ) if id
                 == <self::VftMetadata<M> as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: vft_metadata_meta::__DecimalsParams = sails::scale_codec::Decode::decode(
+                let request: vft_metadata_meta::__DecimalsParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -99,7 +99,7 @@ impl<M: InfallibleStorage<Item = Metadata>> VftMetadataExposure<VftMetadata<M>> 
                 1u16,
             ) if id
                 == <self::VftMetadata<M> as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: vft_metadata_meta::__NameParams = sails::scale_codec::Decode::decode(
+                let request: vft_metadata_meta::__NameParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");
@@ -125,7 +125,7 @@ impl<M: InfallibleStorage<Item = Metadata>> VftMetadataExposure<VftMetadata<M>> 
                 2u16,
             ) if id
                 == <self::VftMetadata<M> as sails::meta::Identifiable>::INTERFACE_ID => {
-                let request: vft_metadata_meta::__SymbolParams = sails::scale_codec::Decode::decode(
+                let request: vft_metadata_meta::__SymbolParams = sails::scale_codec::DecodeAll::decode_all(
                         &mut input,
                     )
                     .expect("Failed to decode params");

--- a/rs/src/gstd/macros.rs
+++ b/rs/src/gstd/macros.rs
@@ -449,14 +449,12 @@ mod tests {
     fn constructor_params_decoder_rejects_trailing_bytes() {
         let mut payload = (42_u32, 7_u64).encode();
         let mut input = payload.as_slice();
-        let params: (u32, u64) =
-            crate::scale_codec::DecodeAll::decode_all(&mut input).unwrap();
+        let params: (u32, u64) = crate::scale_codec::DecodeAll::decode_all(&mut input).unwrap();
         assert_eq!(params, (42, 7));
 
         payload.push(0);
         let mut input = payload.as_slice();
-        let result: Result<(u32, u64), _> =
-            crate::scale_codec::DecodeAll::decode_all(&mut input);
+        let result: Result<(u32, u64), _> = crate::scale_codec::DecodeAll::decode_all(&mut input);
         assert!(result.is_err());
     }
 

--- a/rs/src/gstd/macros.rs
+++ b/rs/src/gstd/macros.rs
@@ -398,6 +398,32 @@ mod tests {
     }
 
     #[test]
+    fn decode_invocation_params_rejects_trailing_bytes() {
+        const INTERFACE_ID: crate::meta::InterfaceId =
+            crate::meta::InterfaceId::from_bytes_8([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        invocation_io!(
+            struct __DecodeParams {
+                value: u32,
+            },
+            interface_id = INTERFACE_ID,
+            entry_id = 7,
+        );
+
+        let mut payload = crate::meta::SailsMessageHeader::v1(INTERFACE_ID, 7, 0).to_bytes();
+        payload.extend_from_slice(&42_u32.encode());
+
+        let params = crate::gstd::decode_invocation_params::<__DecodeParams>(&payload).unwrap();
+        assert_eq!(params.value, 42);
+
+        payload.push(0);
+        assert!(matches!(
+            crate::gstd::decode_invocation_params::<__DecodeParams>(&payload),
+            Err(crate::errors::Error::Codec(_))
+        ));
+    }
+
+    #[test]
     fn invocation_io_macro_defaults_interface_id_to_zero() {
         invocation_io!(
             pub struct __BarParams {

--- a/rs/src/gstd/macros.rs
+++ b/rs/src/gstd/macros.rs
@@ -424,6 +424,44 @@ mod tests {
     }
 
     #[test]
+    fn service_params_decoder_rejects_trailing_bytes() {
+        invocation_io!(
+            struct __ServiceParams {
+                value: u32,
+            },
+            entry_id = 8,
+        );
+
+        let mut payload = 42_u32.encode();
+        let mut input = payload.as_slice();
+        let params: __ServiceParams =
+            crate::scale_codec::DecodeAll::decode_all(&mut input).unwrap();
+        assert_eq!(params.value, 42);
+
+        payload.push(0);
+        let mut input = payload.as_slice();
+        let result: Result<__ServiceParams, _> =
+            crate::scale_codec::DecodeAll::decode_all(&mut input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn constructor_params_decoder_rejects_trailing_bytes() {
+        let mut payload = (42_u32, 7_u64).encode();
+        let mut input = payload.as_slice();
+        let params: (u32, u64) =
+            crate::scale_codec::DecodeAll::decode_all(&mut input).unwrap();
+        assert_eq!(params, (42, 7));
+
+        payload.push(0);
+        let mut input = payload.as_slice();
+        let result: Result<(u32, u64), _> =
+            crate::scale_codec::DecodeAll::decode_all(&mut input);
+        assert!(result.is_err());
+    }
+
+
+    #[test]
     fn invocation_io_macro_defaults_interface_id_to_zero() {
         invocation_io!(
             pub struct __BarParams {

--- a/rs/src/gstd/macros.rs
+++ b/rs/src/gstd/macros.rs
@@ -460,7 +460,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-
     #[test]
     fn invocation_io_macro_defaults_interface_id_to_zero() {
         invocation_io!(

--- a/rs/src/gstd/mod.rs
+++ b/rs/src/gstd/mod.rs
@@ -131,7 +131,6 @@ where
     DecodeAll::decode_all(&mut value).map_err(Error::Codec)
 }
 
-
 /// SCALE-encode a reply payload prefixed with the Sails header derived from `I`,
 /// passing the encoded bytes to the caller's closure.
 pub fn encode_invocation_payload<I, T, R>(value: &T, route_idx: u8, f: impl FnOnce(&[u8]) -> R) -> R

--- a/rs/src/gstd/mod.rs
+++ b/rs/src/gstd/mod.rs
@@ -131,6 +131,7 @@ where
     DecodeAll::decode_all(&mut value).map_err(Error::Codec)
 }
 
+
 /// SCALE-encode a reply payload prefixed with the Sails header derived from `I`,
 /// passing the encoded bytes to the caller's closure.
 pub fn encode_invocation_payload<I, T, R>(value: &T, route_idx: u8, f: impl FnOnce(&[u8]) -> R) -> R

--- a/rs/src/gstd/mod.rs
+++ b/rs/src/gstd/mod.rs
@@ -26,6 +26,7 @@ use crate::{
     utils::MaybeUninitBufferWriter,
 };
 use gcore::stack_buffer;
+use parity_scale_codec::DecodeAll;
 
 #[cfg(feature = "ethexe")]
 mod ethexe;
@@ -127,8 +128,7 @@ where
     if header.entry_id() != I::ENTRY_ID {
         return Err(Error::Rtl(RtlError::InvocationPrefixMismatches));
     }
-    let value: I::Params = Decode::decode(&mut value).map_err(Error::Codec)?;
-    Ok(value)
+    DecodeAll::decode_all(&mut value).map_err(Error::Codec)
 }
 
 /// SCALE-encode a reply payload prefixed with the Sails header derived from `I`,


### PR DESCRIPTION
## Problem

`decode_invocation_params` decoded the expected SCALE parameters but did not require them to consume the full invocation payload. A valid parameter prefix followed by extra bytes was therefore accepted.

## Fix

Use `DecodeAll` after validating the Sails header so invocation parameters must consume every remaining byte. Add regression coverage proving valid payloads still decode and trailing bytes are rejected.

## Verification

- `cargo test -p sails` (24 passed, 4 ignored)
- `cargo clippy -p sails --all-targets -- -D warnings`
